### PR TITLE
MES-6460 Removing hardcoded AppVersion from AppConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "serve:local": "run-s update-mock-data copy-mock-data config:local && ionic serve",
     "serve:emulator": "npm run config:dev-tools && ionic cap run ios",
     "serve:ipad:notworking": "npm run config:dev && npm run schema-version",
-    "open:ios": "rm -rf ios && ionic build && ionic cap add ios & ionic cap copy ios && npm run copy-resources && ionic cap open ios",
+    "open:ios": "rm -rf ios && npm run config:dev && ionic build && ionic cap add ios & ionic cap copy ios && npm run copy-resources && ionic cap open ios",
     "build": "npm run copy-resources && ionic build",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --fix --ext .ts",

--- a/src/app/providers/app-config/app-config.ts
+++ b/src/app/providers/app-config/app-config.ts
@@ -180,11 +180,7 @@ export class AppConfigProvider {
 
     this.appInfoProvider.getMajorAndMinorVersionNumber()
       .then((version: string) => {
-        console.log('app version', version);
-
-        // TEMP: this temporary version is in here until we fix the app version provider
-        const tempVersion = '4.0';
-        const url = `${this.environmentFile.configUrl}?app_version=${tempVersion}`;
+        const url = `${this.environmentFile.configUrl}?app_version=${version}`;
         this.httpClient.get(url)
           .pipe(timeout(30000))
           .subscribe(

--- a/src/app/providers/app-info/__mocks__/app-info.mock.ts
+++ b/src/app/providers/app-info/__mocks__/app-info.mock.ts
@@ -5,5 +5,5 @@ export class AppInfoProviderMock {
   getVersionNumber = jasmine.createSpy('getVersionNumber').and.returnValue(of('4.0.0'));
 
   getMajorAndMinorVersionNumber = jasmine
-    .createSpy('getMajorAndMinorVersionNumber').and.returnValue(Promise.resolve(4.0));
+    .createSpy('getMajorAndMinorVersionNumber').and.returnValue(Promise.resolve('4.0'));
 }


### PR DESCRIPTION
## Description

The `AppInforProvider` is working correctly, just the place that it reads the `AppVersion` is not the `config.xml`, but it's the `Info.plist` and the key is `CFBundleShortVersionString`. In order for the emulator or the physical device be able to GET the remote config data, this short version string has to be set. This app should start from version `4.0.0`.

This PR also corrects the `AppInfoProviderMock` and adds an extra step to `open:ios` script.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
