### PR TITLE
MES-6579  / Global App Styles for background & cards

### DIFF
--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -132,6 +132,10 @@ $mes-toolbar-background: #212121;
   --ion-color-light-contrast-rgb: 0, 0, 0;
   --ion-color-light-shade: #d7d8da;
   --ion-color-light-tint: #f5f6f9;
+
+  /** app styles **/
+  --ion-background-color: var(--mes-background);
+  --ion-card-background: var(--mes-white);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
## Description
Apply app styles for a default content background colour and a default card colour

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="574" alt="Screenshot 2021-02-18 at 09 07 14" src="https://user-images.githubusercontent.com/33056264/108337773-657f2d80-71cd-11eb-85c4-3966ef279d31.png">
<img width="595" alt="Screenshot 2021-02-18 at 09 25 17" src="https://user-images.githubusercontent.com/33056264/108337788-6912b480-71cd-11eb-9c9a-a31a9773ad4d.png">
