### PR TITLE
reapply guard to splash screen

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -85,6 +85,7 @@ describe('AppComponent', () => {
       spyOn(Plugins.SplashScreen, 'hide');
       spyOn(component, 'initialiseAuthentication');
       spyOn(component, 'initialisePersistentStorage').and.returnValue(Promise.resolve());
+      spyOn(component, 'hideSplashscreen').and.returnValue(Promise.resolve());
       spyOn(component, 'configureStatusBar').and.returnValue(Promise.resolve());
       spyOn(component, 'disableMenuSwipe').and.returnValue(Promise.resolve());
     });
@@ -94,7 +95,7 @@ describe('AppComponent', () => {
       expect(component.initialiseAuthentication).toHaveBeenCalled();
       expect(component.initialisePersistentStorage).toHaveBeenCalled();
       expect(store$.dispatch).toHaveBeenCalledWith(LoadAppVersion());
-      expect(Plugins.SplashScreen.hide).toHaveBeenCalled();
+      expect(component.hideSplashscreen).toHaveBeenCalled();
       expect(component.configureStatusBar).toHaveBeenCalled();
       expect(component.disableMenuSwipe).toHaveBeenCalled();
     }));
@@ -171,6 +172,18 @@ describe('AppComponent', () => {
       component.configureStatusBar();
       flushMicrotasks();
       expect(Plugins.StatusBar.setStyle).toHaveBeenCalledWith({ style: StatusBarStyle.Dark });
+    }));
+  });
+
+  describe('hideSplashscreen', () => {
+    beforeEach(() => {
+      spyOn(Capacitor, 'isPluginAvailable').and.returnValue(true);
+      spyOn(Plugins.SplashScreen, 'hide');
+    });
+    it('should hide splashscreen if plugin is available', fakeAsync(() => {
+      component.hideSplashscreen();
+      flushMicrotasks();
+      expect(Plugins.SplashScreen.hide).toHaveBeenCalled();
     }));
   });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -44,18 +44,17 @@ export class AppComponent extends LogoutBasePageComponent implements OnInit {
 
   async ngOnInit() {
     await this.platform.ready();
-    const { SplashScreen } = Plugins;
     this.initialiseNetworkState();
     this.initialiseAuthentication();
     await this.initialisePersistentStorage();
     this.store$.dispatch(LoadAppVersion());
+    await this.hideSplashscreen();
     await this.configureStatusBar();
     if (this.platform.is('cordova')) {
       this.configureAccessibility();
       this.configurePlatformSubscriptions();
     }
     await this.disableMenuSwipe();
-    await SplashScreen.hide();
     this.logoutEnabled$ = this.store$.select(selectLogoutEnabled);
   }
 
@@ -135,6 +134,13 @@ export class AppComponent extends LogoutBasePageComponent implements OnInit {
     if (Capacitor.isPluginAvailable('StatusBar')) {
       const { StatusBar } = Plugins;
       await StatusBar.setStyle({ style: StatusBarStyle.Dark });
+    }
+  };
+
+  hideSplashscreen = async (): Promise<void> => {
+    if (Capacitor.isPluginAvailable('SplashScreen')) {
+      const { SplashScreen } = Plugins;
+      await SplashScreen.hide();
     }
   };
 


### PR DESCRIPTION
## Description

re-created PR after corruption of previous.

Added a function to guard against hiding the splash screen if the plugin is unavailable

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
