### PR TITLE
MES-6947 - Journal Page - refactor journal slot card

### DIFF
--- a/src/components/test-slot/candidate-link/candidate-link.html
+++ b/src/components/test-slot/candidate-link/candidate-link.html
@@ -1,9 +1,7 @@
-<div>
-  <button class="mes-transparent-button" ion-button (click)="openCandidateDetailsModal()">
+<ion-button expand="full" fill="clear" class="candidate-position" (click)="openCandidateDetailsModal()">
     <h3 class="candidate-name" [ngClass]="{
-      'candidate-name-short': isPortrait,
-      'candidate-name-long': !isPortrait
+      'candidate-name-portrait': isPortrait,
+      'candidate-name-landscape': !isPortrait
     }">{{name.title}} {{name.firstName}} {{name.lastName}}</h3>
-    <ion-icon name="chevron-forward"></ion-icon>
-  </button>
-</div>
+    <ion-icon class="candidate-icon" name="chevron-forward"></ion-icon>
+</ion-button>

--- a/src/components/test-slot/candidate-link/candidate-link.scss
+++ b/src/components/test-slot/candidate-link/candidate-link.scss
@@ -10,11 +10,11 @@
     text-overflow: ellipsis;
 
     &.candidate-name-portrait {
-      max-width: 295px;
+      max-width: 285px;
     }
 
     &.candidate-name-landscape {
-      max-width: 360px;
+      max-width: 350px;
     }
   }
 }

--- a/src/components/test-slot/candidate-link/candidate-link.scss
+++ b/src/components/test-slot/candidate-link/candidate-link.scss
@@ -1,27 +1,24 @@
-div {
-
-  button {
-    display: flex;
-    justify-content: center;
-    align-items: center;
+:host {
+  .candidate-position{
+    position: relative;
+    left: -20px;
   }
-
-  h3.candidate-name {
+  .candidate-name {
+    white-space: nowrap;
     text-align: left;
     overflow: hidden;
     text-overflow: ellipsis;
-    &.candidate-name-short {
-      max-width: 300px;
+
+    &.candidate-name-portrait {
+      max-width: 295px;
     }
-    &.candidate-name-long {
-      max-width: 420px;
+
+    &.candidate-name-landscape {
+      max-width: 360px;
     }
   }
-  ion-icon {
-    padding-left: 6px;
-    padding-right: 10px;
-    font-size: 14px;
-    font-weight: bold;
-    margin-top: 3px;
-  }
+}
+
+.candidate-icon {
+  color: var(--gds-black);
 }

--- a/src/components/test-slot/candidate-link/candidate-link.ts
+++ b/src/components/test-slot/candidate-link/candidate-link.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 import { Name } from '@dvsa/mes-journal-schema';
 import { ModalController } from '@ionic/angular';
 import { CandidateDetailsPage } from '@pages/candidate-details/candidate-details.page';
-import { AppComponent } from '../../../app/app.component';
+import { AppComponent } from '@app/app.component';
 
 @Component({
   selector: 'candidate-link',

--- a/src/components/test-slot/examiner-name/examiner-name.html
+++ b/src/components/test-slot/examiner-name/examiner-name.html
@@ -1,11 +1,3 @@
-<div>
-<ion-grid>
-<ion-row>
-<ion-col>
-        <span class="outcome">
-          <p class="examiner-name">{{examinerName}}</p>
-        </span>
-</ion-col>
-</ion-row>
-</ion-grid>
+<div class="examiner-name">
+    {{examinerName}}
 </div>

--- a/src/components/test-slot/examiner-name/examiner-name.scss
+++ b/src/components/test-slot/examiner-name/examiner-name.scss
@@ -1,4 +1,12 @@
 .examiner-name {
-  font-size: 23px;
   color: black;
+  .text-zoom-regular & {
+    font-size: 18px;
+  }
+  .text-zoom-large & {
+    font-size: 24px;
+  }
+  .text-zoom-x-large & {
+    font-size: 28px;
+  }
 }

--- a/src/components/test-slot/indicators/indicators.scss
+++ b/src/components/test-slot/indicators/indicators.scss
@@ -1,3 +1,0 @@
-div {
-  padding-left: 8px;
-}

--- a/src/components/test-slot/language/__tests__/language.spec.ts
+++ b/src/components/test-slot/language/__tests__/language.spec.ts
@@ -41,14 +41,14 @@ describe('LanguageComponent', () => {
       it('should render text when the language is Welsh', () => {
         component.welshLanguage = true;
         fixture.detectChanges();
-        const renderedText = fixture.debugElement.query(By.css('h6.language-description'))
+        const renderedText = fixture.debugElement.query(By.css('h6.language-padding'))
           .nativeElement;
         expect(renderedText.textContent).toBe('Cymraeg');
       });
       it('should not render text when the language is not Welsh', () => {
         component.welshLanguage = false;
         fixture.detectChanges();
-        const renderedText = fixture.debugElement.queryAll(By.css('h6.language-description'));
+        const renderedText = fixture.debugElement.queryAll(By.css('h6.language-padding'));
         expect(renderedText.length).toBe(0);
       });
     });

--- a/src/components/test-slot/language/language.html
+++ b/src/components/test-slot/language/language.html
@@ -1,6 +1,6 @@
 <div class="welsh-language-indicator" *ngIf="welshLanguage">
-  <div class="language-logo">
-    <img src="assets/imgs/journal/welsh-red-dragon-hi.png" alt="Welsh" />
+  <div class="language-padding">
+    <img class="dragon"src="assets/imgs/journal/welsh-red-dragon-hi.png" alt="Welsh" />
   </div>
-  <h6 class="language-description">Cymraeg</h6>
+  <h6 class="language-padding">Cymraeg</h6>
 </div>

--- a/src/components/test-slot/language/language.scss
+++ b/src/components/test-slot/language/language.scss
@@ -1,22 +1,24 @@
-div.welsh-language-indicator {
+.welsh-language-indicator {
   display: flex;
-  position: relative;
-  top: 10px;
-  left: 20px;
+  justify-content: left;
+  align-items: center;
+}
 
-  img {
-    height: 19px;
-    width: 30px;
-    .text-zoom-large & {
-      height: 22px;
-      width: 35px;
-    }
-    .text-zoom-x-large & {
-      height: 24px;
-      width: 38px;
-    }
+.dragon {
+  height: 19px;
+  width: 30px;
+
+  .text-zoom-large & {
+    height: 22px;
+    width: 35px;
   }
-  .language-description {
-    padding-left: 10px;
+
+  .text-zoom-x-large & {
+    height: 24px;
+    width: 38px;
   }
+}
+
+.language-padding {
+  padding-left: 5px;
 }

--- a/src/components/test-slot/test-outcome/test-outcome.html
+++ b/src/components/test-slot/test-outcome/test-outcome.html
@@ -1,4 +1,4 @@
-<div class="activity-alignment" *ngIf="showOutcome()">
+<div class="activity-alignment outcome" *ngIf="showOutcome()">
     <h2>{{activityCode}}</h2>
 </div>
 <div *ngIf="showTestActionButton && !showOutcome()" class="outcome-position">

--- a/src/components/test-slot/test-outcome/test-outcome.html
+++ b/src/components/test-slot/test-outcome/test-outcome.html
@@ -1,50 +1,34 @@
-<div float-right>
-  <ion-grid no-padding>
-    <ion-row align-items-right>
-      <ion-col *ngIf="showOutcome()">
-        <span class="outcome">
-          <h2>{{activityCode}}</h2>
-        </span>
-      </ion-col>
-      <div *ngIf="showTestActionButton">
-      <ion-col *ngIf="showRekeyButton(); else nonRekey">
-        <span>
-          <ion-button class="mes-secondary-button mes-rekey-button" (click)="rekeyTest()" [disabled]="!canStartTest">
+<div class="activity-alignment" *ngIf="showOutcome()">
+    <h2>{{activityCode}}</h2>
+</div>
+<div *ngIf="showTestActionButton && !showOutcome()" class="outcome-position">
+    <ion-col *ngIf="showRekeyButton(); else nonRekey">
+        <ion-button class="mes-secondary-button mes-rekey-button" (click)="rekeyTest()"
+                    [disabled]="!canStartTest">
             <h3 class="write-up-label">Rekey</h3>
-          </ion-button>
-        </span>
-      </ion-col>
-      <ng-template #nonRekey>
+        </ion-button>
+    </ion-col>
+    <ng-template #nonRekey>
         <ion-col *ngIf="showDelegatedExaminerRekeyButton()">
-          <span>
             <ion-button class="mes-secondary-button mes-delegated-button" (click)="rekeyDelegatedTest()">
-              <h3 class="write-up-label">Rekey</h3>
+                <h3 class="write-up-label">Rekey</h3>
             </ion-button>
-          </span>
         </ion-col>
         <ion-col *ngIf="showResumeButton()">
-          <span>
             <ion-button class="mes-secondary-button mes-warning-button" (click)="clickStartOrResumeTest()">
-              <h3 class="write-up-label">Resume</h3>
+                <h3 class="write-up-label">Resume</h3>
             </ion-button>
-          </span>
         </ion-col>
         <ion-col *ngIf="showStartTestButton()">
-          <span>
-            <ion-button class="mes-primary-button" (click)="clickStartOrResumeTest()" [disabled]="!canStartTest">
-              <h3>Start test</h3>
+            <ion-button class="mes-primary-button" (click)="clickStartOrResumeTest()"
+                        [disabled]="!canStartTest">
+                <h3>Start test</h3>
             </ion-button>
-          </span>
         </ion-col>
         <ion-col *ngIf="showWriteUpButton()">
-          <span>
             <ion-button class="mes-secondary-button mes-warning-button" (click)="writeUpTest()">
-              <h3 class="write-up-label">Write-up</h3>
+                <h3 class="write-up-label">Write-up</h3>
             </ion-button>
-          </span>
         </ion-col>
-      </ng-template>
-      </div>
-    </ion-row>
-  </ion-grid>
+    </ng-template>
 </div>

--- a/src/components/test-slot/test-outcome/test-outcome.scss
+++ b/src/components/test-slot/test-outcome/test-outcome.scss
@@ -1,18 +1,35 @@
-test-outcome {
-  .button-ios {
-    margin: 0;
-  }
+:host {
   .write-up-label {
     color: inherit;
   }
+
   .mes-rekey-button {
     --background: var(--gds-blue);
     --color: var(--mes-white);
     --box-shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.5);
   }
+
   .mes-delegated-button {
     --background: var(--gds-blue);
     --color: var(--mes-white);
     --box-shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.5);
+  }
+
+  .outcome-position {
+    .text-zoom-large & {
+      position: relative;
+      left: -10px;
+    }
+
+    .text-zoom-x-large & {
+      position: relative;
+      left: -15px;
+    }
+  }
+
+  .activity-alignment {
+    display: flex;
+    justify-content: center;
+    align-items: center;
   }
 }

--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -1,114 +1,115 @@
 <location *ngIf="showLocation && !isTeamJournal" [location]="slot.testCentre.centreName">
 </location>
+
 <ion-card [ngClass]="{'test-slot-portrait-mode': isPortrait()}">
-  <ion-row class="slot-row ion-align-items-center ion-nowrap">
     <div class="slot-changed-indicator" [ngClass]="{ 'slot-changed': hasSlotChanged }"></div>
+
     <ion-grid>
-      <ion-row class="slot-header" [ngClass]="{'vehicle-details-displayed': showVehicleDetails()}">
-        <ion-col class="no-padding">
-          <language [welshLanguage]="slot.booking.application.welshTest">
-          </language>
-        </ion-col>
-        <ion-col *ngIf=isTeamJournal>
-          <div class="team-journal-test-centre-name">{{slot.testCentre.centreName}}</div>
-        </ion-col>
-        <ion-col class="no-padding" *ngIf=!isTeamJournal>
-          <submission-status float-end [testStatus]="componentState.testStatus$ | async"></submission-status>
-        </ion-col>
-      </ion-row>
-      <ion-row class="slot-main align-center">
-        <ion-col class="time-exclamation-col">
-          <ion-grid class="no-padding">
-            <ion-row class="align-center">
-              <ion-col class="exclamation-col">
-                <indicators [showExclamationIndicator]="isIndicatorNeededForSlot()" [testStatus]="componentState.testStatus$ | async">
-                </indicators>
-              </ion-col>
-              <ion-col class="align-center">
-                <time [time]="slot.slotDetail.start" [testComplete]="testComplete">
-                </time>
-              </ion-col>
-            </ion-row>
-          </ion-grid>
-        </ion-col>
-        <ion-col  class="align-center">
-          <ion-grid>
-            <ion-row  class="align-center">
-              <ion-col>
-                <ng-content *ngIf="slot.booking.candidate; then candidateLink else unknownCandidate">
-                </ng-content>
-              </ion-col>
-              <ion-col class="category-col align-center">
-                <test-category [category]="slot.booking.application.testCategory"></test-category>
-              </ion-col>
-            </ion-row>
-          </ion-grid>
-        </ion-col>
-        <ion-col *ngIf="teamJournalCandidateResult" class="team-journal-examiner-name">
-          <examiner-name [examinerName]="examinerName"></examiner-name>
-        </ion-col>
-        <ion-col *ngIf="!teamJournalCandidateResult" class="test-outcome-col">
-          <test-outcome
-            class="align-center"
-            [slotDetail]="slot.slotDetail"
-            [canStartTest]="canStartTest()"
-            [isDelegatedTest]="delegatedTest"
-            [examinerId]="getExaminerId()"
-            [testStatus]="componentState.testStatus$ | async"
-            [activityCode]="componentState.testActivityCode$ | async"
-            [specialRequirements]="isIndicatorNeededForSlot()"
-            [hasSeenCandidateDetails]="hasSeenCandidateDetails"
-            [isRekey]="componentState.isRekey$ | async"
-            [category]="slot.booking.application.testCategory"
-            [showTestActionButton]="!isTeamJournal">
-          </test-outcome>
-        </ion-col>
-      </ion-row>
-      <ion-row *ngIf="isTeamJournal">
-        <ion-col no-padding>
-          <div id="team-journal-driver-number" class="team-journal-driver-number">{{slot.booking.candidate.driverNumber}}</div>
-        </ion-col>
-      </ion-row>
-      <ion-row *ngIf="!isTeamJournal" class="slot-footer" [ngClass]="{'vehicle-details-displayed': showVehicleDetails()}" align-items-center>
-        <ion-col class="progressive-access-col">
-          <date *ngIf="delegatedTest" id="del-ex-date" [date]="slot.slotDetail.start">
-          </date>
-          <progressive-access align-items-center [progressiveAccess]="slot.booking.application.progressiveAccess">
-          </progressive-access>
-        </ion-col>
-        <ion-col class="vehicle-details-col" no-padding>
-          <h3 id="del-ex-driver-number" *ngIf="delegatedTest && slot.booking.candidate.driverNumber">{{slot.booking.candidate.driverNumber}}</h3>
+        <ion-row>
+            <ion-col size="79">
 
-          <vehicle-details
-            *ngIf="showVehicleDetails() && !delegatedTest"
-            [height]="slot.booking.application.vehicleHeight"
-            [width]="slot.booking.application.vehicleWidth"
-            [length]="slot.booking.application.vehicleLength"
-            [seats]="slot.booking.application.vehicleSeats"
-            [transmission]="slot.booking.application.vehicleGearbox"
-            [showNumberOfSeats]="showVehicleDetails()"
-          ></vehicle-details>
+                <ion-row>
+                    <ion-col size="2"></ion-col>
+                    <ion-col size="24" class="no-padding">
+                        <language [welshLanguage]="slot.booking.application.welshTest">
+                        </language>
+                    </ion-col>
+                    <ion-col size="70">
+                        <div *ngIf=isTeamJournal
+                             class="team-journal-test-centre-name">{{slot.testCentre.centreName}}</div>
+                        <submission-status *ngIf=!isTeamJournal float-end
+                                           [testStatus]="componentState.testStatus$ | async"></submission-status>
+                    </ion-col>
+                </ion-row>
 
-          <additional-candidate-details
-            *ngIf="showAdditionalCandidateDetails()"
-            [prn]="slot.booking.candidate.prn"
-            [attempts]="slot.booking.candidate.previousADITests"
-          ></additional-candidate-details>
-        </ion-col>
-      </ion-row>
+                <ion-row>
+                    <ion-col size="2"></ion-col>
+                    <ion-col size="7" class="exclamation-col align-center">
+                        <indicators [showExclamationIndicator]="isIndicatorNeededForSlot()"
+                                    [testStatus]="componentState.testStatus$ | async">
+                        </indicators>
+                    </ion-col>
+                    <ion-col size="17" class="align-center">
+                        <time [time]="slot.slotDetail.start" [testComplete]="testComplete">
+                        </time>
+                    </ion-col>
+                    <ion-col size="46" class="vertical-align-center">
+                        <ng-content *ngIf="slot.booking.candidate; then candidateLink else unknownCandidate">
+                        </ng-content>
+                    </ion-col>
+                    <ion-col size="24" class="align-center">
+                        <test-category [category]="slot.booking.application.testCategory"></test-category>
+                    </ion-col>
+                </ion-row>
+
+                <ion-row>
+                    <ion-col size="7"></ion-col>
+                    <ion-col size="19">
+                        <date *ngIf="delegatedTest" id="del-ex-date" [date]="slot.slotDetail.start">
+                        </date>
+                        <progressive-access [progressiveAccess]="slot.booking.application.progressiveAccess">
+                        </progressive-access>
+                    </ion-col>
+                    <ion-col size="70">
+                        <div *ngIf="isTeamJournal" id="team-journal-driver-number"
+                             class="team-journal-driver-number">{{slot.booking.candidate.driverNumber}}</div>
+                        <h3 id="del-ex-driver-number"
+                            *ngIf="delegatedTest && slot.booking.candidate.driverNumber">{{slot.booking.candidate.driverNumber}}</h3>
+                        <vehicle-details
+                                *ngIf="showVehicleDetails() && !delegatedTest && !isTeamJournal"
+                                [height]="slot.booking.application.vehicleHeight"
+                                [width]="slot.booking.application.vehicleWidth"
+                                [length]="slot.booking.application.vehicleLength"
+                                [seats]="slot.booking.application.vehicleSeats"
+                                [transmission]="slot.booking.application.vehicleGearbox"
+                                [showNumberOfSeats]="showVehicleDetails()">
+                        </vehicle-details>
+
+                        <additional-candidate-details
+                                *ngIf="showAdditionalCandidateDetails() && !isTeamJournal"
+                                [prn]="slot.booking.candidate.prn"
+                                [attempts]="slot.booking.candidate.previousADITests">
+                        </additional-candidate-details>
+                    </ion-col>
+                </ion-row>
+            </ion-col>
+
+            <ion-col size="17" class="align-center">
+                <test-outcome
+                        *ngIf="!teamJournalCandidateResult"
+                        [slotDetail]="slot.slotDetail"
+                        [canStartTest]="canStartTest()"
+                        [isDelegatedTest]="delegatedTest"
+                        [examinerId]="getExaminerId()"
+                        [testStatus]="componentState.testStatus$ | async"
+                        [activityCode]="componentState.testActivityCode$ | async"
+                        [specialRequirements]="isIndicatorNeededForSlot()"
+                        [hasSeenCandidateDetails]="hasSeenCandidateDetails"
+                        [isRekey]="componentState.isRekey$ | async"
+                        [category]="slot.booking.application.testCategory"
+                        [showTestActionButton]="!isTeamJournal">
+                </test-outcome>
+                <examiner-name
+                        *ngIf="teamJournalCandidateResult"
+                        [examinerName]="examinerName">
+                </examiner-name>
+            </ion-col>
+        </ion-row>
     </ion-grid>
-  </ion-row>
+
 </ion-card>
+
 <ng-template #candidateLink>
-  <candidate-link *ngIf="canViewCandidateDetails()" [slot]="slot" [slotChanged]="hasSlotChanged" [name]="slot.booking.candidate.candidateName"
-    > <!-- [isPortrait]="isPortrait()" -->
-  </candidate-link>
-  <button *ngIf="!canViewCandidateDetails()" class="mes-transparent-button" ion-button disabled>
-    <h3 class="candidate-name">Candidate details unavailable</h3>
-  </button>
+    <candidate-link *ngIf="canViewCandidateDetails()" [slot]="slot" [slotChanged]="hasSlotChanged"
+                    [name]="slot.booking.candidate.candidateName"
+                    [isPortrait]="isPortrait()">
+    </candidate-link>
+    <ion-button *ngIf="!canViewCandidateDetails()" class="mes-transparent-button" disabled>
+        <h3 class="candidate-name">Candidate details unavailable</h3>
+    </ion-button>
 </ng-template>
 <ng-template #unknownCandidate>
-  <button class="mes-transparent-button" ion-button disabled>
-    <h3 class="candidate-name">Trainer booked - unnamed</h3>
-  </button>
+    <ion-button class="mes-transparent-button" disabled>
+        <h3 class="candidate-name">Trainer booked - unnamed</h3>
+    </ion-button>
 </ng-template>

--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -14,7 +14,8 @@
                         <language [welshLanguage]="slot.booking.application.welshTest">
                         </language>
                     </ion-col>
-                    <ion-col size="70">
+                    <ion-col size="2"></ion-col>
+                    <ion-col size="68">
                         <div *ngIf=isTeamJournal
                              class="team-journal-test-centre-name">{{slot.testCentre.centreName}}</div>
                         <submission-status *ngIf=!isTeamJournal float-end

--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -33,7 +33,8 @@
                         <time [time]="slot.slotDetail.start" [testComplete]="testComplete">
                         </time>
                     </ion-col>
-                    <ion-col size="46" class="vertical-align-center">
+                    <ion-col size="2"></ion-col>
+                    <ion-col size="44" class="vertical-align-center">
                         <ng-content *ngIf="slot.booking.candidate; then candidateLink else unknownCandidate">
                         </ng-content>
                     </ion-col>
@@ -50,7 +51,8 @@
                         <progressive-access [progressiveAccess]="slot.booking.application.progressiveAccess">
                         </progressive-access>
                     </ion-col>
-                    <ion-col size="70">
+                    <ion-col size="2"></ion-col>
+                    <ion-col size="68">
                         <div *ngIf="isTeamJournal" id="team-journal-driver-number"
                              class="team-journal-driver-number">{{slot.booking.candidate.driverNumber}}</div>
                         <h3 id="del-ex-driver-number"

--- a/src/components/test-slot/test-slot/test-slot.scss
+++ b/src/components/test-slot/test-slot/test-slot.scss
@@ -9,10 +9,14 @@ ion-card {
 }
 
 ion-row {
+  //turn on for debugging of test-slot card
+  //border: 1px solid black;
   min-height: 30px;
 }
 
 ion-col {
+  //turn on for debugging of test-slot card
+  //border: 1px solid black;
   padding: 0;
 }
 

--- a/src/components/test-slot/test-slot/test-slot.scss
+++ b/src/components/test-slot/test-slot/test-slot.scss
@@ -4,140 +4,39 @@ ion-card {
 
   ion-grid {
     height: 100%;
-    padding: 0;
+    padding: 10px;
   }
 }
 
 ion-row {
-  &.slot-row {
-    min-height: 108px;
-    position: relative;
-
-    &.test-slot-portrait-mode {
-      min-height: 108px;
-    }
-  }
-
-  &.slot-header,
-  &.slot-footer {
-    min-height: 22px;
-    padding-right: 4px;
-
-    &.vehicle-details-displayed {
-      min-height: 34px;
-    }
-  }
-
-  &.slot-main {
-    min-height: 48px;
-  }
+  min-height: 30px;
 }
 
 ion-col {
   padding: 0;
-
-  &.time-exclamation-col {
-    padding-left: 8px;
-    max-width: 152px;
-
-    .text-zoom-large & {
-      max-width: 172px;
-    }
-
-    .text-zoom-x-large & {
-      max-width: 192px;
-    }
-  }
-
-  &.exclamation-col {
-    max-width: 48px;
-  }
-
-  &.test-outcome-col {
-    max-width: 152px;
-
-    .text-zoom-large & {
-      max-width: 172px;
-    }
-
-    .text-zoom-x-large & {
-      max-width: 192px;
-    }
-  }
-
-  &.vehicle-details-col {
-    margin-top: -10px;
-
-    .text-zoom-large & {
-      padding-left: 20px;
-    }
-
-    .text-zoom-x-large & {
-      padding-left: 40px;
-    }
-  }
-
-  &.progressive-access-col {
-    max-width: 152px;
-    margin-top: -6px;
-  }
-
-  &.category-col {
-    padding-right: 8px;
-    flex-grow: 0;
-  }
-
-  &.team-journal-examiner-name {
-    max-height: 20px;
-    margin-top: -50px;
-    max-width: 152px;
-
-    .text-zoom-large & {
-      margin-top: -80px;
-      max-width: 172px;
-    }
-
-    .text-zoom-x-large & {
-      margin-top: -110px;
-      max-width: 192px;
-    }
-  }
 }
 
 .team-journal-test-centre-name {
-  position: absolute;
-  left: -215px;
   color: #000;
-
   .text-zoom-regular & {
     font-size: 18px;
-    top: 10px;
   }
-
   .text-zoom-large & {
     font-size: 24px;
-    top: 20px;
   }
-
   .text-zoom-x-large & {
     font-size: 28px;
-    top: 40px;
   }
 }
 
 .team-journal-driver-number {
-  margin-top: -10px;
-  padding-left: 168px;
   color: #000;
-
   .text-zoom-regular & {
     font-size: 18px;
   }
-
   .text-zoom-large & {
     font-size: 24px;
   }
-
   .text-zoom-x-large & {
     font-size: 28px;
   }
@@ -163,12 +62,7 @@ ion-col {
   align-items: center;
 }
 
-#del-ex-driver-number {
-  padding: 0px 10px;
-}
-
-#del-ex-date {
-  position: relative;
-  left: 125px;
-  bottom: 5px;
+.vertical-align-center {
+  display: flex;
+  align-items: center;
 }

--- a/src/components/test-slot/test-slot/test-slot.ts
+++ b/src/components/test-slot/test-slot/test-slot.ts
@@ -116,6 +116,7 @@ export class TestSlotComponent implements SlotComponent, OnInit {
 
   isPortrait(): boolean {
     return this.screenOrientation.type === this.screenOrientation.ORIENTATIONS.PORTRAIT_PRIMARY
+      || this.screenOrientation.type === this.screenOrientation.ORIENTATIONS.PORTRAIT_SECONDARY
       || this.screenOrientation.type === this.screenOrientation.ORIENTATIONS.PORTRAIT;
   }
 

--- a/src/components/test-slot/vehicle-details/vehicle-details.html
+++ b/src/components/test-slot/vehicle-details/vehicle-details.html
@@ -1,14 +1,6 @@
 <div class="vehicle-details-row">
-  <span padding-right>
     <span>L: </span><span class="bold">{{ length }}</span>
-  </span>
-  <span padding-right>
     <span>W: </span><span class="bold">{{ width }}</span>
-  </span>
-  <span padding-right>
     <span>H: </span><span class="bold">{{ height }}</span>
-  </span>
-  <span padding-right>
     <span *ngIf="showNumberOfSeats">Seats: </span><span class="bold">{{ seats }}</span>
-  </span>
 </div>

--- a/src/components/test-slot/vehicle-details/vehicle-details.scss
+++ b/src/components/test-slot/vehicle-details/vehicle-details.scss
@@ -1,12 +1,13 @@
-.bold {
-  font-weight: bold;
-}
+:host {
+  .bold {
+    font-weight: bold;
+  }
 
-span {
-  padding-left: 0.25rem;
-}
+  span {
+    padding-left: 0.25rem;
+  }
 
-.vehicle-details-row {
-  padding-left: 5px;
-  color: var(--gds-black);
+  .vehicle-details-row {
+    color: var(--gds-black);
+  }
 }


### PR DESCRIPTION
## Description

refactor the journal slot card to rely on ion-grid rather then pure css

Notes for review.
Need to be checked for landscape and portrait, for regular, large and x-large text size, for journal, and both team journal paged. obviously Mod2 has the longest category type so that needs to be viewed (in large size).  completed tests as well. Welsh tests.  tests with vehicle details (Cat C will work).  oh and i think mobexaminer6 has a 'PROG' test (progressive access), but i may be wrong.  Lastly I found that you can use safari to ammend the data to trigger the max length of a candidate name so that the '...' kicks in.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/48550267/121702573-e8542d00-cac9-11eb-89f2-7e2ac0a4ac86.png)
![image](https://user-images.githubusercontent.com/48550267/121702605-edb17780-cac9-11eb-95dd-8d5a3550fd55.png)
![image](https://user-images.githubusercontent.com/48550267/121702612-f1dd9500-cac9-11eb-81ce-f210660c513b.png)
![image](https://user-images.githubusercontent.com/48550267/121702627-f609b280-cac9-11eb-8767-355f92ae6175.png)

updated screen shot with space between time and name
![image](https://user-images.githubusercontent.com/48550267/122881606-3e7b6880-d333-11eb-84e7-dc3be4d186a0.png)
