### PR TITLE
MES-6881 Fix issue with buttons wrapping with bold text on

### DIFF
--- a/src/app/pages/test-report/components/competency/competency.scss
+++ b/src/app/pages/test-report/components/competency/competency.scss
@@ -7,9 +7,6 @@
       width: 100%;
       justify-content: center;
     }
-    .competency-label {
-      margin-left: 15px;
-    }
 
     .fault-wrapper {
       display: flex;

--- a/src/app/pages/test-report/components/controlled-stop/controlled-stop.html
+++ b/src/app/pages/test-report/components/controlled-stop/controlled-stop.html
@@ -26,7 +26,7 @@
       }"
     >
       <driving-faults-badge class="driving-faults" [count]="faultCount()"></driving-faults-badge>
-      <div class='competency-label'>Controlled stop</div>
+      <div>Controlled stop</div>
       <div class="fault-wrapper">
         <serious-fault-badge [showBadge]="hasSeriousFault()"></serious-fault-badge>
         <dangerous-fault-badge [showBadge]="hasDangerousFault()"></dangerous-fault-badge>

--- a/src/app/pages/test-report/components/controlled-stop/controlled-stop.scss
+++ b/src/app/pages/test-report/components/controlled-stop/controlled-stop.scss
@@ -30,7 +30,7 @@
       padding-right: 5px;
 
       driving-faults-badge {
-        width: 30px;
+        width: 27px;
       }
 
       .fault-wrapper {


### PR DESCRIPTION
## Description
- Fixes issue with bold text setting causing certain competency buttons to wrap on 10.2" ipad

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/33055124/124145031-5fa32e00-da84-11eb-8a4b-0f7b21b3bde3.png)
