### PR TITLE
mes-6981: add min height for buttons on WRTC screen

### DIFF
--- a/src/app/pages/waiting-room-to-car/cat-b/waiting-room-to-car.cat-b.page.html
+++ b/src/app/pages/waiting-room-to-car/cat-b/waiting-room-to-car.cat-b.page.html
@@ -77,7 +77,7 @@
         <ion-col size="45" class="ion-text-center">
             <ion-button
                     shape="round"
-                    class="mes-grey-button full-button-widths"
+                    class="mes-grey-button wrtc-footer-btn"
                     (click)="onViewTestCentreJournal()">
                 <h3>View test centre journal</h3>
             </ion-button>
@@ -86,7 +86,7 @@
         <ion-col size="45" class="ion-text-center">
             <ion-button
                     shape="round"
-                    class="mes-primary-button full-button-widths"
+                    class="mes-primary-button wrtc-footer-btn"
                     id="continue-to-test-report-button" (click)="onSubmit()">
                 <h3>Continue to test report</h3>
             </ion-button>

--- a/src/app/pages/waiting-room-to-car/cat-b/waiting-room-to-car.cat-b.page.scss
+++ b/src/app/pages/waiting-room-to-car/cat-b/waiting-room-to-car.cat-b.page.scss
@@ -24,7 +24,8 @@ ion-footer {
     }
   }
 
-  .full-button-widths {
+  .wrtc-footer-btn {
     width: 100%;
+    min-height: 56px;
   }
 }


### PR DESCRIPTION
## Description

resize buttons on wtrc screen to match other screens

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

<img width="614" alt="Screenshot 2021-07-21 at 13 05 10" src="https://user-images.githubusercontent.com/48550267/126486323-fa823328-bb3e-4020-8f09-f1c0922a197a.png">
<img width="625" alt="Screenshot 2021-07-21 at 13 10 22" src="https://user-images.githubusercontent.com/48550267/126486334-8b9a149a-9834-413c-aa6e-fa339ddff2ab.png">

