### PR TITLE
MES-6985: Journal refresh scroll bug

### DIFF
--- a/src/app/pages/journal/__tests__/journal.page.spec.ts
+++ b/src/app/pages/journal/__tests__/journal.page.spec.ts
@@ -180,6 +180,12 @@ describe('JournalPage', () => {
         expect(insomnia.allowSleepAgain).toHaveBeenCalled();
       });
     });
+    describe('setScrollTop', () => {
+      it('should set scrollTop value', () => {
+        component.setScrollTop(1000);
+        expect(component.scrollTop).toEqual(1000);
+      });
+    });
   });
 
   describe('DOM', () => {

--- a/src/app/pages/journal/journal.page.html
+++ b/src/app/pages/journal/journal.page.html
@@ -17,7 +17,7 @@
     </ion-toolbar>
 </ion-header>
 
-<ion-content no-padding>
+<ion-content no-padding [scrollEvents]="true" (ionScroll)="setScrollTop($event.detail.scrollTop)">
     <offline-banner [isOffline]="pageState.isOffline$ | async"></offline-banner>
 
     <!--  @TODO - Reintroduce with MES-6271-->


### PR DESCRIPTION
## Description

### Issue:
Dynamic slot creation on Journal page causes issues in Ionic 5. Calling `ViewContainerRef` mothods such as `.clear()` or `.remove()` causes the view to return to the top of the `ion-content`, losing the current scroll position when the journal is silently refreshed (every 20s).

### Solution:
The following changes have been implemented to resolve the above:
- Pipe slot emission through the rxjs `distinctUntilChanged` operator to ensure dynamic components are only regenerated on data changes. 
- continually capture and record the current scroll position within the `ion-content`  so that, where dynamic components must be re-generated, we can return the user to the  original position once the components are refreshed.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
