### PR TITLE
mes-7156: add no-watch flag to command to facilitate pipeline build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "postinstall": "node buildScripts/crypto-patch.js && node buildScripts/eslint-alloc-patch.js",
     "test": "npm run config:dev && ng test --no-watch --karma-config test-config/karma.conf.js",
     "test:reload": "npm run config:dev && ng test --watch --karma-config test-config/karma.conf.js",
-    "test:coverage": "npm run config:dev && ng test --karma-config test-config/karma.conf.js",
+    "test:coverage": "npm run config:dev && ng test --no-watch --karma-config test-config/karma.conf.js",
     "remote-devtools-server": "./bin/remote-devtools-server.sh",
     "serve:local": "run-s update-mock-data copy-mock-data schema-version config:local && ionic serve",
     "serve:emulator": "npm run schema-version && npm run config:dev && ionic cap run ios",


### PR DESCRIPTION
## Description

Update an existing test coverage command to prevent terminal from persisting after a test run.  This has been done to slow the pipeline to run a test command which generates a coverage report

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
