### PR TITLE
MES-6816 Fixed bug to display 'Terminated' test

### DIFF
--- a/src/components/common/end-test-link/end-test-link.ts
+++ b/src/components/common/end-test-link/end-test-link.ts
@@ -5,6 +5,9 @@ import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/
 import { TestFlowPageNames } from '@pages/page-names.constants';
 import { TerminateTestModal } from '@pages/terminate-test-modal/terminate-test-modal';
 import { RouteByCategoryProvider } from '@providers/route-by-category/route-by-category';
+import { SetActivityCode } from '@store/tests/activity-code/activity-code.actions';
+import { Store } from '@ngrx/store';
+import { StoreModel } from '@shared/models/store.model';
 
 @Component({
   selector: 'end-test-link',
@@ -28,6 +31,7 @@ export class EndTestLinkComponent {
     public modalController: ModalController,
     public router: Router,
     public routerByCategory: RouteByCategoryProvider,
+    private store$: Store<StoreModel>,
   ) {
   }
 
@@ -58,6 +62,7 @@ export class EndTestLinkComponent {
       await this.routerByCategory.navigateToPage(TestFlowPageNames.OFFICE_PAGE, this.category as TestCategory);
       return;
     }
+    this.store$.dispatch(SetActivityCode(null));
     await this.router.navigate([TestFlowPageNames.DEBRIEF_PAGE]);
   };
 


### PR DESCRIPTION
## Description
Added an action to set activityCode to null in order to default test outcome to 'Terminated' when clicking End Test button

## Checklist
- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

<img width="515" alt="Screenshot 2021-09-24 at 09 20 26" src="https://user-images.githubusercontent.com/45790769/134642419-53c1b03b-0361-4643-8c34-45addc88f55f.png">