### PR TITLE
MES-7366 / Add guard TCJ when no candidate details

### DIFF
--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -59,8 +59,8 @@
                     </ion-col>
                     <ion-col size="2"></ion-col>
                     <ion-col size="68">
-                        <div *ngIf="isTeamJournal && !isTestCentreJournalADIBooking()" id="driver-number-{{slot.booking.candidate.driverNumber}}"
-                             class="team-journal-driver-number">{{slot.booking.candidate.driverNumber}}</div>
+                        <div *ngIf="isTeamJournal && !isTestCentreJournalADIBooking()" id="driver-number-{{slot.booking?.candidate?.driverNumber}}"
+                             class="team-journal-driver-number">{{slot.booking?.candidate?.driverNumber}}</div>
                         <h3 id="del-ex-driver-number"
                             *ngIf="delegatedTest && slot.booking.candidate.driverNumber">{{slot.booking.candidate.driverNumber}}</h3>
                         <vehicle-details


### PR DESCRIPTION
## Description
- Add guard to test centre journal for when no candidate object is returned. This was causing a run time issue means slot creation was broken

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
