### PR TITLE
Jasmine form warnings

### DIFF
--- a/src/app/pages/office/cat-b/__tests__/office.cat-b.page.spec.ts
+++ b/src/app/pages/office/cat-b/__tests__/office.cat-b.page.spec.ts
@@ -42,6 +42,7 @@ import { EyesightTestFailed } from '@store/tests/test-data/common/eyesight-test/
 import { AddSeriousFault } from '@store/tests/test-data/common/serious-faults/serious-faults.actions';
 import { ActivityCodeDescription, ActivityCodeModel } from '@shared/constants/activity-code/activity-code.constants';
 import { ActivityCodeComponent } from '@components/common/activity-code/activity-code';
+import { ReactiveFormsModule } from '@angular/forms';
 import { DateOfTest } from '../../components/date-of-test/date-of-test';
 import { CandidateSectionComponent } from '../../components/candidate-section/candidate-section';
 import { ToastControllerMock } from '../../__mocks__/toast-controller-mock';
@@ -127,6 +128,7 @@ describe('OfficePage', () => {
             },
           }),
         }),
+        ReactiveFormsModule,
       ],
       providers: [
         { provide: Platform, useFactory: () => PlatformMock.instance() },

--- a/src/app/pages/office/components/candidate-section/__tests__/candidate-section.spec.ts
+++ b/src/app/pages/office/components/candidate-section/__tests__/candidate-section.spec.ts
@@ -4,6 +4,7 @@ import { configureTestSuite } from 'ng-bullet';
 
 import { AppModule } from 'src/app/app.module';
 import { TestOutcome } from '@store/tests/tests.constants';
+import { ReactiveFormsModule } from '@angular/forms';
 import { CandidateSectionComponent } from '../candidate-section';
 
 describe('CandidateSectionComponent', () => {
@@ -18,8 +19,8 @@ describe('CandidateSectionComponent', () => {
       imports: [
         IonicModule,
         AppModule,
+        ReactiveFormsModule,
       ],
-      providers: [],
     });
   });
 

--- a/src/app/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
+++ b/src/app/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
@@ -3,7 +3,7 @@ import { MockComponent } from 'ng-mocks';
 import { IonicModule } from '@ionic/angular';
 import { By } from '@angular/platform-browser';
 import { AppModule } from 'src/app/app.module';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { FaultCommentComponent } from '../../fault-comment/fault-comment';
 import { FaultCommentCardComponent } from '../fault-comment-card';
@@ -21,6 +21,7 @@ describe('FaultCommentCardComponent', () => {
       imports: [
         IonicModule,
         AppModule,
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/app/pages/office/components/fault-comment/__tests__/fault-comment.spec.ts
+++ b/src/app/pages/office/components/fault-comment/__tests__/fault-comment.spec.ts
@@ -5,7 +5,7 @@ import { By } from '@angular/platform-browser';
 import {
   DrivingFaultsBadgeComponent,
 } from '@components/common/driving-faults-badge/driving-faults-badge';
-import { FormGroup, FormControl } from '@angular/forms';
+import { FormGroup, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/outcome-behaviour-map';
 import { CommentSource } from '@shared/models/fault-marking.model';
 import { configureTestSuite } from 'ng-bullet';
@@ -29,6 +29,7 @@ describe('FaultCommentComponent', () => {
         AppModule,
         ComponentsModule,
         PipesModule,
+        ReactiveFormsModule,
       ],
       providers: [
         { provide: OutcomeBehaviourMapProvider, useClass: OutcomeBehaviourMapProvider },

--- a/src/app/pages/pass-finalisation/components/code-78/__tests__/code-78.spec.ts
+++ b/src/app/pages/pass-finalisation/components/code-78/__tests__/code-78.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, async, TestBed } from '@angular/core/testing';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { IonicModule } from '@ionic/angular';
 import { Code78Component } from '../code-78';
@@ -15,8 +15,7 @@ describe('code78Component', () => {
       ],
       imports: [
         IonicModule,
-      ],
-      providers: [
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/app/pages/pass-finalisation/components/license-provided/__tests__/license-provided.spec.ts
+++ b/src/app/pages/pass-finalisation/components/license-provided/__tests__/license-provided.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { IonicModule } from '@ionic/angular';
 import { LicenseProvidedComponent } from '../license-provided';
@@ -15,8 +15,7 @@ describe('licenseProvidedComponent', () => {
       ],
       imports: [
         IonicModule,
-      ],
-      providers: [
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/app/pages/rekey-reason/components/ipad-issue/__tests__/ipad-issue.spec.ts
+++ b/src/app/pages/rekey-reason/components/ipad-issue/__tests__/ipad-issue.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, waitForAsync, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { By } from '@angular/platform-browser';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { IpadIssueComponent } from '../ipad-issue';
 
@@ -18,8 +18,8 @@ describe('IpadIssueComponent', () => {
       imports: [
         IonicModule,
         AppModule,
+        ReactiveFormsModule,
       ],
-      providers: [],
     });
   });
 

--- a/src/app/pages/rekey-reason/components/other-reason/__tests__/other-reason.spec.ts
+++ b/src/app/pages/rekey-reason/components/other-reason/__tests__/other-reason.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, waitForAsync, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { By } from '@angular/platform-browser';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { OtherReasonComponent } from '../other-reason';
 
@@ -18,8 +18,8 @@ describe('OtherReasonComponent', () => {
       imports: [
         IonicModule,
         AppModule,
+        ReactiveFormsModule,
       ],
-      providers: [],
     });
   });
 

--- a/src/app/pages/rekey-reason/components/transfer/__tests__/transfer.spec.ts
+++ b/src/app/pages/rekey-reason/components/transfer/__tests__/transfer.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, waitForAsync, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { By } from '@angular/platform-browser';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { TransferComponent } from '../transfer';
 
@@ -18,8 +18,8 @@ describe('TransferComponent', () => {
       imports: [
         IonicModule,
         AppModule,
+        ReactiveFormsModule,
       ],
-      providers: [],
     });
   });
 

--- a/src/app/pages/waiting-room-to-car/cat-b/components/instructor-registration/__tests__/instructor-registration.spec.ts
+++ b/src/app/pages/waiting-room-to-car/cat-b/components/instructor-registration/__tests__/instructor-registration.spec.ts
@@ -1,5 +1,5 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
 import { configureTestSuite } from 'ng-bullet';
 import { InstructorRegistrationComponent } from '../instructor-registration';
@@ -22,6 +22,7 @@ describe('InstructorRegistrationComponent', () => {
       ],
       imports: [
         IonicModule,
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/app/pages/waiting-room-to-car/cat-b/components/tell-me-question-outcome/__tests__/tell-me-question-outcome.spec.ts
+++ b/src/app/pages/waiting-room-to-car/cat-b/components/tell-me-question-outcome/__tests__/tell-me-question-outcome.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, waitForAsync, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 import { By } from '@angular/platform-browser';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { TellMeQuestionOutcomeComponent } from '../tell-me-question-outcome';
 import { AppModule } from '../../../../../../app.module';
@@ -18,6 +18,7 @@ describe('TellMeQuestionOutcomeComponent', () => {
       imports: [
         IonicModule,
         AppModule,
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/app/pages/waiting-room-to-car/cat-home-test/__tests__/waiting-room-to-car.cat-home-test.page.spec.ts
+++ b/src/app/pages/waiting-room-to-car/cat-home-test/__tests__/waiting-room-to-car.cat-home-test.page.spec.ts
@@ -4,16 +4,20 @@ import { NavMock } from '@mocks/angular-mocks/nav-mock';
 import { RouteByCategoryProvider } from '@providers/route-by-category/route-by-category';
 import { RouteByCategoryProviderMock } from '@providers/route-by-category/__mocks__/route-by-category.mock';
 
+import { ReactiveFormsModule } from '@angular/forms';
 import { WaitingRoomToCarCatHomeTestPage } from '../waiting-room-to-car.cat-home-test.page';
 
-describe('WaitingRoomToCar.CatHomeTestPage', () => {
+describe('WaitingRoomToCarCatHomeTestPage', () => {
   let component: WaitingRoomToCarCatHomeTestPage;
   let fixture: ComponentFixture<WaitingRoomToCarCatHomeTestPage>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [WaitingRoomToCarCatHomeTestPage],
-      imports: [IonicModule.forRoot()],
+      imports: [
+        IonicModule.forRoot(),
+        ReactiveFormsModule,
+      ],
       providers: [
         { provide: NavController, useClass: NavMock },
         { provide: RouteByCategoryProvider, useClass: RouteByCategoryProviderMock },

--- a/src/app/pages/waiting-room-to-car/components/eyesight-failure-confirmation/__tests__/eyesight-failure-confirmation.spec.ts
+++ b/src/app/pages/waiting-room-to-car/components/eyesight-failure-confirmation/__tests__/eyesight-failure-confirmation.spec.ts
@@ -12,6 +12,7 @@ import { SetActivityCode } from '@store/tests/activity-code/activity-code.action
 import { RouterMock } from '@mocks/angular-mocks/router-mock';
 import { Router } from '@angular/router';
 
+import { ReactiveFormsModule } from '@angular/forms';
 import { EyesightFailureConfirmationComponent } from '../eyesight-failure-confirmation';
 
 describe('EyesightFailureConfirmationComponent', () => {
@@ -30,6 +31,7 @@ describe('EyesightFailureConfirmationComponent', () => {
         StoreModule.forRoot({
           tests: testsReducer,
         }),
+        ReactiveFormsModule,
       ],
       providers: [
         { provide: Config, useFactory: () => ConfigMock.instance() },

--- a/src/app/pages/waiting-room-to-car/components/eyesight-test/__tests__/eyesight-test.spec.ts
+++ b/src/app/pages/waiting-room-to-car/components/eyesight-test/__tests__/eyesight-test.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, waitForAsync, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 import { By } from '@angular/platform-browser';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { EyesightTestComponent } from '../eyesight-test';
 import { AppModule } from '../../../../../app.module';
@@ -18,6 +18,7 @@ describe('EyesightTestComponent', () => {
       imports: [
         IonicModule,
         AppModule,
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/app/pages/waiting-room-to-car/components/vehicle-checks-completed/__tests__/vehicle-checks-completed.spec.ts
+++ b/src/app/pages/waiting-room-to-car/components/vehicle-checks-completed/__tests__/vehicle-checks-completed.spec.ts
@@ -1,7 +1,7 @@
 import { By } from '@angular/platform-browser';
 import { ComponentFixture, waitForAsync, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
@@ -20,6 +20,7 @@ describe('VehicleChecksToggleComponent', () => {
       imports: [
         IonicModule,
         AppModule,
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/app/pages/waiting-room-to-car/components/vehicle-details/__tests__/vehicle-details.spec.ts
+++ b/src/app/pages/waiting-room-to-car/components/vehicle-details/__tests__/vehicle-details.spec.ts
@@ -3,8 +3,8 @@ import { IonicModule } from '@ionic/angular';
 import { By } from '@angular/platform-browser';
 import { FormGroup } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
+import { AppModule } from '@app/app.module';
 import { VehicleDetailsComponent } from '../vehicle-details';
-import { AppModule } from '../../../../../app.module';
 
 describe('VehicleDetailsComponent', () => {
   let fixture: ComponentFixture<VehicleDetailsComponent>;

--- a/src/app/pages/waiting-room/components/insurance-declaration/__tests__/insurance-declaration.spec.ts
+++ b/src/app/pages/waiting-room/components/insurance-declaration/__tests__/insurance-declaration.spec.ts
@@ -7,7 +7,7 @@ import {
   TranslateLoader,
   TranslateParser,
 } from '@ngx-translate/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { InsuranceDeclarationComponent } from '../insurance-declaration';
 
@@ -23,6 +23,7 @@ describe('InsuranceDeclarationComponent', () => {
       imports: [
         IonicModule,
         TranslateModule.forRoot(),
+        ReactiveFormsModule,
       ],
       providers: [
         TranslateService,

--- a/src/app/pages/waiting-room/components/residency-declaration/__tests__/residency-declaration.spec.ts
+++ b/src/app/pages/waiting-room/components/residency-declaration/__tests__/residency-declaration.spec.ts
@@ -7,7 +7,7 @@ import {
   TranslateLoader,
   TranslateParser,
 } from '@ngx-translate/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { ResidencyDeclarationComponent } from '../residency-declaration';
 
@@ -23,6 +23,7 @@ describe('ResidencyDeclarationComponent', () => {
       imports: [
         IonicModule,
         TranslateModule.forRoot(),
+        ReactiveFormsModule,
       ],
       providers: [
         TranslateService,

--- a/src/components/common/health-declaration-signed/__tests__/health-declaration-signed.spec.ts
+++ b/src/components/common/health-declaration-signed/__tests__/health-declaration-signed.spec.ts
@@ -1,6 +1,6 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { configureTestSuite } from 'ng-bullet';
 import { HealthDeclarationSignedComponent } from '../health-declaration-signed';
 
@@ -15,8 +15,7 @@ describe('HealthDeclarationSignedComponent', () => {
       ],
       imports: [
         IonicModule,
-      ],
-      providers: [
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/components/common/signature/__tests__/signature.spec.ts
+++ b/src/components/common/signature/__tests__/signature.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, waitForAsync, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 import { TranslateModule } from '@ngx-translate/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MockComponent } from 'ng-mocks';
 import { SignatureAreaComponent } from '@components/common/signature-area/signature-area';
 import { configureTestSuite } from 'ng-bullet';
@@ -20,6 +20,7 @@ describe('SignatureComponent', () => {
       imports: [
         IonicModule,
         TranslateModule.forRoot(),
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/components/common/transmission/__tests__/transmission.spec.ts
+++ b/src/components/common/transmission/__tests__/transmission.spec.ts
@@ -1,11 +1,11 @@
 import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { TransmissionType } from '@shared/models/transmission-type';
 import { configureTestSuite } from 'ng-bullet';
 import { TransmissionComponent } from '../transmission';
 
-describe('transmissionComponent', () => {
+describe('TransmissionComponent', () => {
   let fixture: ComponentFixture<TransmissionComponent>;
   let component: TransmissionComponent;
 
@@ -16,8 +16,7 @@ describe('transmissionComponent', () => {
       ],
       imports: [
         IonicModule,
-      ],
-      providers: [
+        ReactiveFormsModule,
       ],
     });
   });

--- a/src/components/test-slot/additional-candidate-details/__tests__/additional-candidate-details.spec.ts
+++ b/src/components/test-slot/additional-candidate-details/__tests__/additional-candidate-details.spec.ts
@@ -3,7 +3,7 @@ import { IonicModule } from '@ionic/angular';
 import { configureTestSuite } from 'ng-bullet';
 import { AdditionalCandidateDetailsComponent } from '../additional-candidate-details';
 
-describe('VehicleDetailsComponent', () => {
+describe('AdditionalCandidateDetailsComponent', () => {
   let fixture: ComponentFixture<AdditionalCandidateDetailsComponent>;
   let component: AdditionalCandidateDetailsComponent;
 


### PR DESCRIPTION
## Description
- Add ReactiveFormsModule to unit test imports to avoid unknown attribute warnings (e.g. ```Can't bind to 'ngif' since it isn't a known property of 'ion-row'```)

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
