### PR TITLE
MES-7376 / Inhibit View candidate details action via Test Centre Journal

### DIFF
--- a/src/app/pages/candidate-details/candidate-details.page.ts
+++ b/src/app/pages/candidate-details/candidate-details.page.ts
@@ -33,6 +33,7 @@ export class CandidateDetailsPage implements OnInit {
   pageState: CandidateDetailsPageState;
   slot: TestSlot;
   slotChanged: boolean = false;
+  isTeamJournal: boolean = false;
   testCategory: TestCategory = null;
 
   constructor(
@@ -45,6 +46,8 @@ export class CandidateDetailsPage implements OnInit {
   ngOnInit(): void {
     this.slot = this.navParams.get('slot');
     this.slotChanged = this.navParams.get('slotChanged');
+    this.isTeamJournal = this.navParams.get('isTeamJournal');
+
     setTimeout(() => {
       this.store$.dispatch(journalActions.ClearChangedSlot(this.slot.slotDetail.slotId));
     });
@@ -73,7 +76,10 @@ export class CandidateDetailsPage implements OnInit {
 
   ionViewDidEnter(): void {
     this.store$.dispatch(candidateDetailActions.CandidateDetailsViewDidEnter({ slot: this.slot }));
-    this.store$.dispatch(journalActions.CandidateDetailsSeen({ slotId: this.slot.slotDetail.slotId }));
+
+    if (!this.isTeamJournal) {
+      this.store$.dispatch(journalActions.CandidateDetailsSeen({ slotId: this.slot.slotDetail.slotId }));
+    }
   }
 
   public specialNeedsIsPopulated(specialNeeds: string | string[]): boolean {

--- a/src/app/pages/test-centre-journal/test-centre-journal.module.ts
+++ b/src/app/pages/test-centre-journal/test-centre-journal.module.ts
@@ -8,6 +8,7 @@ import { SlotProvider } from '@providers/slot/slot';
 import { ComponentsModule } from '@components/common/common-components.module';
 import { TestSlotComponentsModule } from '@components/test-slot/test-slot-components.module';
 import { TestCentreJournalAnalyticsEffects } from '@pages/test-centre-journal/test-centre-journal.analytics.effects';
+import { CandidateDetailsPageModule } from '@pages/candidate-details/candidate-details.module';
 
 import { TestCentreJournalPage } from './test-centre-journal.page';
 import { TestCentreJournalRoutingModule } from './test-centre-journal-routing.module';
@@ -25,6 +26,7 @@ import { TestCentreJournalComponentsModule } from './components/test-centre-jour
     EffectsModule.forFeature([
       TestCentreJournalAnalyticsEffects,
     ]),
+    CandidateDetailsPageModule,
   ],
   declarations: [
     TestCentreJournalPage,

--- a/src/app/providers/slot-selector/slot-selector.ts
+++ b/src/app/providers/slot-selector/slot-selector.ts
@@ -158,8 +158,11 @@ export class SlotSelectorProvider {
           (<TestSlotComponent>componentRef.instance).derivedTestStatus = TestStatus.Submitted;
         }
 
-        // if this is a test slot assign hasSeenCandidateDetails separately
-        (<TestSlotComponent>componentRef.instance).hasSeenCandidateDetails = slot.hasSeenCandidateDetails;
+        // stop the hasSeenCandidateDetails boolean being set via the Test centre journal
+        if (!isTeamJournal) {
+          // if this is a test slot assign hasSeenCandidateDetails separately
+          (<TestSlotComponent>componentRef.instance).hasSeenCandidateDetails = slot.hasSeenCandidateDetails;
+        }
       }
     }
   };

--- a/src/components/test-slot/candidate-link/candidate-link.ts
+++ b/src/components/test-slot/candidate-link/candidate-link.ts
@@ -20,6 +20,9 @@ export class CandidateLinkComponent {
   name: Name;
 
   @Input()
+  isTeamJournal: boolean = false;
+
+  @Input()
   applicationId: number;
 
   @Input()
@@ -42,6 +45,7 @@ export class CandidateLinkComponent {
       componentProps: {
         slot: this.slot,
         slotChanged: this.slotChanged,
+        isTeamJournal: this.isTeamJournal,
       },
     });
     await profileModal.present();

--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -110,7 +110,10 @@
 </ion-card>
 
 <ng-template #candidateLink>
-    <candidate-link *ngIf="canViewCandidateDetails() && !isTestCentreJournalADIBooking()" [slot]="slot" [slotChanged]="hasSlotChanged"
+    <candidate-link *ngIf="canViewCandidateDetails() && !isTestCentreJournalADIBooking()"
+                    [slot]="slot"
+                    [slotChanged]="hasSlotChanged"
+                    [isTeamJournal]="isTeamJournal"
                     [name]="slot.booking.candidate.candidateName"
                     [applicationId]="slot.booking.application.applicationId"
                     [isPortrait]="isPortrait()">


### PR DESCRIPTION
## Description
- Add guard to slot creation which will now no longer set hasCandidateDetails on TCJ
- Add guard around action which was previously dispatched via TCJ if viewing own journal
## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
