### PR TITLE
mes-7230: move effects for analytics

### DIFF
--- a/src/store/tests/tests.analytics.effects.ts
+++ b/src/store/tests/tests.analytics.effects.ts
@@ -145,7 +145,6 @@ export class TestsAnalyticsEffects {
   setActivityCode$ = createEffect(() => this.actions$.pipe(
     ofType(
       activityCodeActions.SetActivityCode,
-      passFinalisationActions.PassFinalisationReportActivityCode,
     ),
     concatMap((action) => of(action).pipe(
       withLatestFrom(
@@ -156,6 +155,29 @@ export class TestsAnalyticsEffects {
     )),
     filter(([{ activityCode }]) => activityCode !== null),
     concatMap(([{ activityCode }, tests]: [ReturnType <typeof activityCodeActions.SetActivityCode>, TestsModel]) => {
+      const [description, code] = getEnumKeyByValue(ActivityCodes, activityCode);
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+        formatAnalyticsText(AnalyticsEvents.SET_ACTIVITY_CODE, tests),
+        `${code} - ${description}`,
+      );
+      return of(AnalyticRecorded());
+    }),
+  ));
+
+  passFinalisationReportActivityCode$ = createEffect(() => this.actions$.pipe(
+    ofType(
+      passFinalisationActions.PassFinalisationReportActivityCode,
+    ),
+    concatMap((action) => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([{ activityCode }, tests]:
+    [ReturnType <typeof passFinalisationActions.PassFinalisationReportActivityCode>, TestsModel]) => {
       const [description, code] = getEnumKeyByValue(ActivityCodes, activityCode);
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),


### PR DESCRIPTION
## Description

Move'd existing analytics to the page specific analytics (pass-final) as if it lives in the test analytics it did get associated to the page which gav needs

Post-test for setting activity code is now associated to pass fin screen.

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![image](https://user-images.githubusercontent.com/48550267/144402941-9a3f27c5-c9f4-4b85-bd83-88476e5b1e62.png)

