### PR TITLE
mes-7230: move event to pass finalisations page analytics

### DIFF
--- a/src/store/tests/tests.analytics.effects.ts
+++ b/src/store/tests/tests.analytics.effects.ts
@@ -22,7 +22,6 @@ import { NavigationStateProvider } from '@providers/navigation-state/navigation-
 import { ActivityCodes } from '@shared/models/activity-codes';
 import { getEnumKeyByValue } from '@shared/helpers/enum-keys';
 import * as activityCodeActions from '@store/tests/activity-code/activity-code.actions';
-import * as passFinalisationActions from '@pages/pass-finalisation/pass-finalisation.actions';
 import { TestsModel } from './tests.model';
 import {
   TestOutcomeChanged,
@@ -145,7 +144,6 @@ export class TestsAnalyticsEffects {
   setActivityCode$ = createEffect(() => this.actions$.pipe(
     ofType(
       activityCodeActions.SetActivityCode,
-      passFinalisationActions.PassFinalisationReportActivityCode,
     ),
     concatMap((action) => of(action).pipe(
       withLatestFrom(


### PR DESCRIPTION
## Description

Move'd existing analytics to the page specific analytics (pass-final) as if it lives in the test analytics it did get associated to the page which gav needs

Post-test for setting activity code is now associated to pass fin screen.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

![image](https://user-images.githubusercontent.com/48550267/144404621-edf100bd-0c2c-4c93-aab2-28d3306ca91f.png)

