### PR TITLE
Mes 7267 remove mode changes

### DIFF
--- a/src/app/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
+++ b/src/app/pages/test-report/__tests__/test-report.analytics.effects.spec.ts
@@ -72,6 +72,7 @@ import { CompetencyOutcome } from '@shared/models/competency-outcome';
 import * as highwayCodeActions
   from '@store/tests/test-data/common/highway-code-safety/highway-code-safety.actions';
 import * as etaActions from '@store/tests/test-data/common/eta/eta.actions';
+import { testReportReducer } from '@pages/test-report/test-report.reducer';
 import * as testReportActions from '../test-report.actions';
 import { TestReportAnalyticsEffects } from '../test-report.analytics.effects';
 
@@ -87,6 +88,7 @@ describe('Test Report Analytics Effects', () => {
       imports: [
         StoreModule.forRoot({
           tests: testsReducer,
+          testReport: testReportReducer,
         }),
       ],
       providers: [
@@ -128,6 +130,7 @@ describe('Test Report Analytics Effects', () => {
       // ARRANGE
       store$.dispatch(testsActions.StartTest(123456, TestCategory.B));
       // ACT
+      store$.dispatch(testReportActions.ToggleRemoveFaultMode());
       actions$.next(testReportActions.ToggleRemoveFaultMode(true));
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
@@ -136,6 +139,25 @@ describe('Test Report Analytics Effects', () => {
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           AnalyticsEventCategories.TEST_REPORT,
           AnalyticsEvents.SELECT_REMOVE_MODE,
+          AnalyticsEvents.REMOVE_MODE_SELECTED,
+        );
+        done();
+      });
+    });
+    it('should call logEvent when the action is user generated for untoggling of remove fault mode', (done) => {
+      // ARRANGE
+      store$.dispatch(testsActions.StartTest(123456, TestCategory.B));
+      // ACT
+      store$.dispatch(testReportActions.ToggleRemoveFaultMode());
+      actions$.next(testReportActions.ToggleRemoveFaultMode(true));
+      // ASSERT
+      effects.toggleRemoveFaultMode$.subscribe((result) => {
+        expect(result.type).toEqual(AnalyticRecorded.type);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.TEST_REPORT,
+          AnalyticsEvents.EXIT_REMOVE_MODE,
+          AnalyticsEvents.REMOVE_MODE_EXITED,
         );
         done();
       });
@@ -144,6 +166,7 @@ describe('Test Report Analytics Effects', () => {
       // ARRANGE
       store$.dispatch(testsActions.StartTestReportPracticeTest(testReportPracticeModeSlot.slotDetail.slotId));
       // ACT
+      store$.dispatch(testReportActions.ToggleRemoveFaultMode());
       actions$.next(testReportActions.ToggleRemoveFaultMode(true));
       // ASSERT
       effects.toggleRemoveFaultMode$.subscribe((result) => {
@@ -152,6 +175,7 @@ describe('Test Report Analytics Effects', () => {
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEventCategories.TEST_REPORT}`,
           `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.SELECT_REMOVE_MODE}`,
+          `${AnalyticsEventCategories.PRACTICE_TEST} - ${AnalyticsEvents.REMOVE_MODE_SELECTED}`,
         );
         done();
       });

--- a/src/app/pages/test-report/components/toolbar/__tests__/toolbar.spec.ts
+++ b/src/app/pages/test-report/components/toolbar/__tests__/toolbar.spec.ts
@@ -15,6 +15,7 @@ import { ToggleRemoveFaultMode, ToggleSeriousFaultMode, ToggleDangerousFaultMode
 import { testReportReducer } from '../../../test-report.reducer';
 import { DangerousTooltipComponent } from '../../dangerous-tooltip/dangerous-tooltip';
 import { TimerComponent } from '../../timer/timer';
+import { FaultCountProvider } from '@providers/fault-count/fault-count';
 
 describe('ToolbarComponent', () => {
   let fixture: ComponentFixture<ToolbarComponent>;
@@ -38,6 +39,7 @@ describe('ToolbarComponent', () => {
       providers: [
         { provide: Config, useFactory: () => ConfigMock.instance() },
         { provide: NavController, useFactory: () => NavControllerMock.instance() },
+        { provide: FaultCountProvider, useClass: FaultCountProvider },
       ],
     });
   });

--- a/src/app/pages/test-report/components/toolbar/__tests__/toolbar.spec.ts
+++ b/src/app/pages/test-report/components/toolbar/__tests__/toolbar.spec.ts
@@ -8,6 +8,7 @@ import { MockComponent } from 'ng-mocks';
 import { testsReducer } from '@store/tests/tests.reducer';
 import { StoreModel } from '@shared/models/store.model';
 import { configureTestSuite } from 'ng-bullet';
+import { FaultCountProvider } from '@providers/fault-count/fault-count';
 import { ToolbarComponent } from '../toolbar';
 import { DrivingFaultSummaryComponent } from '../../driving-fault-summary/driving-fault-summary';
 import { SeriousTooltipComponent } from '../../serious-tooltip/serious-tooltip';
@@ -15,7 +16,6 @@ import { ToggleRemoveFaultMode, ToggleSeriousFaultMode, ToggleDangerousFaultMode
 import { testReportReducer } from '../../../test-report.reducer';
 import { DangerousTooltipComponent } from '../../dangerous-tooltip/dangerous-tooltip';
 import { TimerComponent } from '../../timer/timer';
-import { FaultCountProvider } from '@providers/fault-count/fault-count';
 
 describe('ToolbarComponent', () => {
   let fixture: ComponentFixture<ToolbarComponent>;

--- a/src/app/pages/test-report/components/toolbar/toolbar.html
+++ b/src/app/pages/test-report/components/toolbar/toolbar.html
@@ -11,7 +11,7 @@
         'inactive': !isRemoveFaultMode
       }"
         >
-        {{ !isRemoveFaultMode ? 'Remove' : 'Exit remove mode'}}
+        {{ isRemoveFaultMode ? 'Exit remove mode' : 'Remove'}}
       </ion-button>
     </ion-col>
     <ion-col size="12" class="ion-no-padding button-wrapper padding-right-16">

--- a/src/app/pages/test-report/components/toolbar/toolbar.html
+++ b/src/app/pages/test-report/components/toolbar/toolbar.html
@@ -5,12 +5,13 @@
       id="remove-button"
       class="ion-no-padding"
       (click)="toggleRemoveFaultMode()"
+      [disabled]="componentState.shouldDisableRemove$ | async"
       [ngClass]="{
         'active': isRemoveFaultMode,
         'inactive': !isRemoveFaultMode
       }"
         >
-        Remove
+        {{ !isRemoveFaultMode ? 'Remove' : 'Exit remove mode'}}
       </ion-button>
     </ion-col>
     <ion-col size="12" class="ion-no-padding button-wrapper padding-right-16">

--- a/src/app/pages/test-report/components/toolbar/toolbar.ts
+++ b/src/app/pages/test-report/components/toolbar/toolbar.ts
@@ -34,7 +34,6 @@ export class ToolbarComponent {
   isRemoveFaultMode: boolean = false;
   isSeriousMode: boolean = false;
   isDangerousMode: boolean = false;
-  currentTestData: any;
 
   constructor(
     private store$: Store<StoreModel>,

--- a/src/app/pages/test-report/components/toolbar/toolbar.ts
+++ b/src/app/pages/test-report/components/toolbar/toolbar.ts
@@ -2,15 +2,23 @@ import { Component } from '@angular/core';
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '@shared/models/store.model';
 import { Observable, Subscription, merge } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { getTestReportState } from '../../test-report.reducer';
-import { isRemoveFaultMode, isSeriousMode, isDangerousMode } from '../../test-report.selector';
+import { map, withLatestFrom } from 'rxjs/operators';
+import { getCurrentTest } from '@store/tests/tests.selector';
+import { TestDataUnion } from '@shared/unions/test-schema-unions';
+import { getTests } from '@store/tests/tests.reducer';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { FaultCountProvider } from '@providers/fault-count/fault-count';
+import { getTestData } from '@store/tests/test-data/cat-b/test-data.reducer';
+import { getTestCategory } from '@store/tests/category/category.reducer';
 import { ToggleRemoveFaultMode, ToggleSeriousFaultMode, ToggleDangerousFaultMode } from '../../test-report.actions';
+import { isRemoveFaultMode, isSeriousMode, isDangerousMode } from '../../test-report.selector';
+import { getTestReportState } from '../../test-report.reducer';
 
 interface ToolbarComponentState {
   isSeriousMode$: Observable<boolean>;
   isDangerousMode$: Observable<boolean>;
   isRemoveFaultMode$: Observable<boolean>;
+  shouldDisableRemove$: Observable<boolean>;
 }
 
 @Component({
@@ -26,10 +34,19 @@ export class ToolbarComponent {
   isRemoveFaultMode: boolean = false;
   isSeriousMode: boolean = false;
   isDangerousMode: boolean = false;
+  currentTestData: any;
 
-  constructor(private store$: Store<StoreModel>) { }
+  constructor(
+    private store$: Store<StoreModel>,
+    private faultCountProvider: FaultCountProvider,
+  ) {
+  }
 
   ngOnInit(): void {
+    const currentTest$ = this.store$.pipe(
+      select(getTests),
+      select(getCurrentTest),
+    );
     this.componentState = {
       isRemoveFaultMode$: this.store$.pipe(
         select(getTestReportState),
@@ -42,6 +59,13 @@ export class ToolbarComponent {
       isDangerousMode$: this.store$.pipe(
         select(getTestReportState),
         select(isDangerousMode),
+      ),
+      shouldDisableRemove$: currentTest$.pipe(
+        select(getTestData),
+        withLatestFrom(
+          currentTest$.pipe(select(getTestCategory)),
+        ),
+        map(([data, category]) => this.currentTestHasFaults(category as TestCategory, data)),
       ),
     };
 
@@ -79,5 +103,13 @@ export class ToolbarComponent {
     }
     this.store$.dispatch(ToggleDangerousFaultMode(true));
   }
+
+  currentTestHasFaults = (category: TestCategory, data: TestDataUnion): boolean => {
+    const drivingFaultCount: number = this.faultCountProvider.getDrivingFaultSumCount(category, data);
+    const seriousFaultCount: number = this.faultCountProvider.getSeriousFaultSumCount(category, data);
+    const dangerousFaultCount: number = this.faultCountProvider.getDangerousFaultSumCount(category, data);
+
+    return dangerousFaultCount === 0 && seriousFaultCount === 0 && drivingFaultCount === 0;
+  };
 
 }

--- a/src/app/pages/test-report/test-report.analytics.effects.ts
+++ b/src/app/pages/test-report/test-report.analytics.effects.ts
@@ -121,7 +121,6 @@ export class TestReportAnalyticsEffects {
         return of(AnalyticNotRecorded());
       }
 
-
       if (removeFaultMode) {
         this.analytics.logEvent(
           formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),

--- a/src/app/pages/test-report/test-report.analytics.effects.ts
+++ b/src/app/pages/test-report/test-report.analytics.effects.ts
@@ -121,7 +121,6 @@ export class TestReportAnalyticsEffects {
         return of(AnalyticNotRecorded());
       }
 
-      console.log('removeFaultMode:', removeFaultMode);
 
       if (removeFaultMode) {
         this.analytics.logEvent(
@@ -131,7 +130,6 @@ export class TestReportAnalyticsEffects {
         );
         return of(AnalyticRecorded());
       }
-      console.log('This shouldn\'t fire');
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.EXIT_REMOVE_MODE, tests),

--- a/src/app/pages/test-report/test-report.analytics.effects.ts
+++ b/src/app/pages/test-report/test-report.analytics.effects.ts
@@ -121,18 +121,17 @@ export class TestReportAnalyticsEffects {
         return of(AnalyticNotRecorded());
       }
 
-      // this.analytics.logEvent(
-      //   formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
-      //   formatAnalyticsText(removeFaultMode ? AnalyticsEvents.SELECT_REMOVE_MODE : AnalyticsEvents.EXIT_REMOVE_MODE, tests),
-      // );
+      console.log('removeFaultMode:', removeFaultMode);
 
       if (removeFaultMode) {
         this.analytics.logEvent(
           formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
           formatAnalyticsText(AnalyticsEvents.SELECT_REMOVE_MODE, tests),
+          formatAnalyticsText(AnalyticsEvents.REMOVE_MODE_SELECTED, tests),
         );
         return of(AnalyticRecorded());
       }
+      console.log('This shouldn\'t fire');
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.TEST_REPORT, tests),
         formatAnalyticsText(AnalyticsEvents.EXIT_REMOVE_MODE, tests),

--- a/src/app/providers/analytics/analytics.model.ts
+++ b/src/app/providers/analytics/analytics.model.ts
@@ -106,6 +106,7 @@ export enum AnalyticsEvents {
   SELECT_DANGEROUS_MODE = 'select dangerous mode',
   SELECT_REMOVE_MODE = 'select remove mode',
   EXIT_REMOVE_MODE = 'exit remove mode',
+  REMOVE_MODE_SELECTED = 'remove mode selected',
   REMOVE_MODE_EXITED = 'remove mode exited',
   APPLICATION_REFERENCE_SEARCH = 'perform application reference search',
   DRIVER_NUMBER_SEARCH = 'perform driver number search',

--- a/src/app/providers/analytics/analytics.model.ts
+++ b/src/app/providers/analytics/analytics.model.ts
@@ -105,6 +105,8 @@ export enum AnalyticsEvents {
   SELECT_SERIOUS_MODE = 'select serious mode',
   SELECT_DANGEROUS_MODE = 'select dangerous mode',
   SELECT_REMOVE_MODE = 'select remove mode',
+  EXIT_REMOVE_MODE = 'exit remove mode',
+  REMOVE_MODE_EXITED = 'remove mode exited',
   APPLICATION_REFERENCE_SEARCH = 'perform application reference search',
   DRIVER_NUMBER_SEARCH = 'perform driver number search',
   LDTM_SEARCH = 'perform ldtm search',


### PR DESCRIPTION
## Description
Changed text on remove faults button to 'Exit remove mode' when active & disabled it when no faults are present
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="447" alt="Screenshot 2021-12-02 at 14 11 13" src="https://user-images.githubusercontent.com/45790769/144438341-0396665a-a59f-4069-a474-06e6db9694e5.png">
<img width="446" alt="Screenshot 2021-12-02 at 14 10 59" src="https://user-images.githubusercontent.com/45790769/144438343-7bba8671-51b0-4ca7-9efe-433fcfa41b05.png">
<img width="447" alt="Screenshot 2021-12-02 at 14 10 11" src="https://user-images.githubusercontent.com/45790769/144438349-0807e4fc-7bfc-440e-a643-9f1d30eb200c.png">
