### PR TITLE
MES-7228 - moved analytics for activity code

### DIFF
--- a/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
+++ b/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
@@ -298,7 +298,7 @@ describe('NonPassFinalisationAnalyticsEffects', () => {
       // ACT
       actions$.next(nonPassFinalisationActions.NonPassFinalisationReportActivityCode(ActivityCodes.FAIL_PUBLIC_SAFETY));
       // ASSERT
-      effects.NonPassFinalisationReportActivityCode$.subscribe((result) => {
+      effects.nonPassFinalisationReportActivityCode$.subscribe((result) => {
         expect(result.type).toEqual(AnalyticRecorded.type);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
         expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(

--- a/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
+++ b/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
@@ -291,4 +291,24 @@ describe('NonPassFinalisationAnalyticsEffects', () => {
     });
   });
 
+  describe('NonPassFinalisationReportActivityCode', () => {
+    it('should call logEvent for action NonPassFinalisationReportActivityCode', (done) => {
+      // ARRANGE
+      store$.dispatch(testsActions.StartTest(123, TestCategory.C));
+      // ACT
+      actions$.next(nonPassFinalisationActions.NonPassFinalisationReportActivityCode(ActivityCodes.FAIL_PUBLIC_SAFETY));
+      // ASSERT
+      effects.NonPassFinalisationReportActivityCode$.subscribe((result) => {
+        expect(result.type).toEqual(AnalyticRecorded.type);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
+        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
+          AnalyticsEventCategories.POST_TEST,
+          AnalyticsEvents.SET_ACTIVITY_CODE,
+          '4 - FAIL_PUBLIC_SAFETY',
+        );
+        done();
+      });
+    });
+  });
+
 });

--- a/src/app/pages/non-pass-finalisation/non-pass-finalisation.actions.ts
+++ b/src/app/pages/non-pass-finalisation/non-pass-finalisation.actions.ts
@@ -1,7 +1,13 @@
 import { createAction } from '@ngrx/store';
+import { ActivityCode } from '@dvsa/mes-test-schema/categories/common';
 
 export const NonPassFinalisationViewDidEnter = createAction(
   '[NonPassFinalisationPage] NonPassFinalisation view did enter',
+);
+
+export const NonPassFinalisationReportActivityCode = createAction(
+  '[NonPassFinalisationPage] NonPass Finalisation report activity code',
+  (activityCode: ActivityCode) => ({ activityCode }),
 );
 
 export const NonPassFinalisationValidationError = createAction(

--- a/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
+++ b/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
@@ -24,7 +24,6 @@ import * as testSummaryActions from '@store/tests/test-summary/test-summary.acti
 import * as commsActions from '@store/tests/communication-preferences/communication-preferences.actions';
 import { D255No, D255Yes } from '@store/tests/test-summary/test-summary.actions';
 import { ActivityCodeModel } from '@shared/constants/activity-code/activity-code.constants';
-import * as passFinalisationActions from '@pages/pass-finalisation/pass-finalisation.actions';
 import { getEnumKeyByValue } from '@shared/helpers/enum-keys';
 import { ActivityCodes } from '@shared/models/activity-codes';
 import { NonPassFinalisationValidationError, NonPassFinalisationViewDidEnter } from './non-pass-finalisation.actions';
@@ -198,7 +197,7 @@ export class NonPassFinalisationAnalyticsEffects {
 
   NonPassFinalisationReportActivityCode$ = createEffect(() => this.actions$.pipe(
     ofType(
-      passFinalisationActions.PassFinalisationReportActivityCode,
+      nonPassFinalisationActions.NonPassFinalisationReportActivityCode,
     ),
     concatMap((action) => of(action).pipe(
       withLatestFrom(
@@ -208,7 +207,7 @@ export class NonPassFinalisationAnalyticsEffects {
       ),
     )),
     concatMap(([{ activityCode }, tests]:
-    [ReturnType <typeof passFinalisationActions.PassFinalisationReportActivityCode>, TestsModel]) => {
+    [ReturnType <typeof nonPassFinalisationActions.NonPassFinalisationReportActivityCode>, TestsModel]) => {
       const [description, code] = getEnumKeyByValue(ActivityCodes, activityCode);
       this.analytics.logEvent(
         formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),

--- a/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
+++ b/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
@@ -24,8 +24,11 @@ import * as testSummaryActions from '@store/tests/test-summary/test-summary.acti
 import * as commsActions from '@store/tests/communication-preferences/communication-preferences.actions';
 import { D255No, D255Yes } from '@store/tests/test-summary/test-summary.actions';
 import { ActivityCodeModel } from '@shared/constants/activity-code/activity-code.constants';
-import * as nonPassFinalisationActions from './non-pass-finalisation.actions';
+import * as passFinalisationActions from '@pages/pass-finalisation/pass-finalisation.actions';
+import { getEnumKeyByValue } from '@shared/helpers/enum-keys';
+import { ActivityCodes } from '@shared/models/activity-codes';
 import { NonPassFinalisationValidationError, NonPassFinalisationViewDidEnter } from './non-pass-finalisation.actions';
+import * as nonPassFinalisationActions from './non-pass-finalisation.actions';
 
 @Injectable()
 export class NonPassFinalisationAnalyticsEffects {
@@ -190,6 +193,29 @@ export class NonPassFinalisationAnalyticsEffects {
         return of(AnalyticRecorded());
       }
       return of(AnalyticNotRecorded());
+    }),
+  ));
+
+  NonPassFinalisationReportActivityCode$ = createEffect(() => this.actions$.pipe(
+    ofType(
+      passFinalisationActions.PassFinalisationReportActivityCode,
+    ),
+    concatMap((action) => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([{ activityCode }, tests]:
+    [ReturnType <typeof passFinalisationActions.PassFinalisationReportActivityCode>, TestsModel]) => {
+      const [description, code] = getEnumKeyByValue(ActivityCodes, activityCode);
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+        formatAnalyticsText(AnalyticsEvents.SET_ACTIVITY_CODE, tests),
+        `${code} - ${description}`,
+      );
+      return of(AnalyticRecorded());
     }),
   ));
 

--- a/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
+++ b/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
@@ -195,7 +195,7 @@ export class NonPassFinalisationAnalyticsEffects {
     }),
   ));
 
-  NonPassFinalisationReportActivityCode$ = createEffect(() => this.actions$.pipe(
+  nonPassFinalisationReportActivityCode$ = createEffect(() => this.actions$.pipe(
     ofType(
       nonPassFinalisationActions.NonPassFinalisationReportActivityCode,
     ),

--- a/src/app/pages/non-pass-finalisation/non-pass-finalisation.page.ts
+++ b/src/app/pages/non-pass-finalisation/non-pass-finalisation.page.ts
@@ -37,6 +37,7 @@ import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/ou
 import { getTestData } from '@store/tests/test-data/cat-b/test-data.reducer';
 import { hasEyesightTestGotSeriousFault } from '@store/tests/test-data/cat-b/test-data.cat-b.selector';
 import {
+  NonPassFinalisationReportActivityCode,
   NonPassFinalisationValidationError,
   NonPassFinalisationViewDidEnter,
 } from '@pages/non-pass-finalisation/non-pass-finalisation.actions';
@@ -245,6 +246,7 @@ export class NonPassFinalisationPage extends PracticeableBasePageComponent imple
         return;
       }
 
+      this.store$.dispatch(NonPassFinalisationReportActivityCode(this.activityCode.activityCode));
       await this.routeByCat.navigateToPage(TestFlowPageNames.CONFIRM_TEST_DETAILS_PAGE);
       return;
     }

--- a/src/store/tests/__tests__/tests.analytics.effects.spec.ts
+++ b/src/store/tests/__tests__/tests.analytics.effects.spec.ts
@@ -210,26 +210,4 @@ describe('Tests Analytics Effects', () => {
       });
     });
   });
-
-  describe('setActivityCode', () => {
-    it('should call logEvent for set activity code', (done) => {
-      // ARRANGE
-      store$.dispatch(testsActions.StartTest(123456, TestCategory.EUAM1));
-
-      // ACT
-      actions$.next(activityCodeActions.SetActivityCode(ActivityCodes.FAIL_PUBLIC_SAFETY));
-
-      // ASSERT
-      effects.setActivityCode$.subscribe((result) => {
-        expect(result.type).toEqual(AnalyticRecorded.type);
-        expect(analyticsProviderMock.logEvent).toHaveBeenCalledTimes(1);
-        expect(analyticsProviderMock.logEvent).toHaveBeenCalledWith(
-          AnalyticsEventCategories.POST_TEST,
-          AnalyticsEvents.SET_ACTIVITY_CODE,
-          '4 - FAIL_PUBLIC_SAFETY',
-        );
-        done();
-      });
-    });
-  });
 });

--- a/src/store/tests/tests.analytics.effects.ts
+++ b/src/store/tests/tests.analytics.effects.ts
@@ -6,7 +6,7 @@ import {
 import { Store, select } from '@ngrx/store';
 import { StoreModel } from '@shared/models/store.model';
 import {
-  withLatestFrom, switchMap, concatMap, filter,
+  withLatestFrom, switchMap, concatMap,
 } from 'rxjs/operators';
 import {
   AnalyticsEventCategories,
@@ -19,9 +19,6 @@ import { formatApplicationReference } from '@shared/helpers/formatters';
 import { formatAnalyticsText } from '@shared/helpers/format-analytics-text';
 import { Router } from '@angular/router';
 import { NavigationStateProvider } from '@providers/navigation-state/navigation-state';
-import { ActivityCodes } from '@shared/models/activity-codes';
-import { getEnumKeyByValue } from '@shared/helpers/enum-keys';
-import * as activityCodeActions from '@store/tests/activity-code/activity-code.actions';
 import { TestsModel } from './tests.model';
 import {
   TestOutcomeChanged,
@@ -137,29 +134,6 @@ export class TestsAnalyticsEffects {
         AnalyticsEvents.START_TEST,
       );
 
-      return of(AnalyticRecorded());
-    }),
-  ));
-
-  setActivityCode$ = createEffect(() => this.actions$.pipe(
-    ofType(
-      activityCodeActions.SetActivityCode,
-    ),
-    concatMap((action) => of(action).pipe(
-      withLatestFrom(
-        this.store$.pipe(
-          select(getTests),
-        ),
-      ),
-    )),
-    filter(([{ activityCode }]) => activityCode !== null),
-    concatMap(([{ activityCode }, tests]: [ReturnType <typeof activityCodeActions.SetActivityCode>, TestsModel]) => {
-      const [description, code] = getEnumKeyByValue(ActivityCodes, activityCode);
-      this.analytics.logEvent(
-        formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
-        formatAnalyticsText(AnalyticsEvents.SET_ACTIVITY_CODE, tests),
-        `${code} - ${description}`,
-      );
       return of(AnalyticRecorded());
     }),
   ));


### PR DESCRIPTION
## Description

prevent analytics for setting of activity codes in favor of just when leaving either of the finilisation pages

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
