### PR TITLE
MES-7531: rekey reason validators

### DIFF
--- a/src/app/pages/rekey-reason/components/ipad-issue/ipad-issue.ts
+++ b/src/app/pages/rekey-reason/components/ipad-issue/ipad-issue.ts
@@ -97,6 +97,7 @@ export class IpadIssueComponent implements OnChanges {
       this.ipadIssueControl.setValidators([Validators.required]);
     } else {
       this.ipadIssueControl.clearValidators();
+      this.ipadIssueControl.updateValueAndValidity();
     }
 
     if (this.selected && (!this.technicalFault && !this.lost && !this.stolen && !this.broken)) {


### PR DESCRIPTION
Validators on rekey reason, ipad issue were not clearing when item deselected.
added call to updateValueAndValidity after validator removed as per documentation for clearValidators

## Description

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
