### PR TITLE
mes-7105 bug fixes

### DIFF
--- a/src/app/pages/view-test-result/components/speed-card/speed-card.scss
+++ b/src/app/pages/view-test-result/components/speed-card/speed-card.scss
@@ -5,3 +5,7 @@
     min-width: 25px;
   }
 }
+
+ion-row {
+  color: black;
+}

--- a/src/app/pages/view-test-result/components/test-details-card/test-details-card.html
+++ b/src/app/pages/view-test-result/components/test-details-card/test-details-card.html
@@ -34,13 +34,15 @@
             </data-row-custom>
 
             <data-row
-                    *ngIf="data.entitlementCheck"
+                    *ngIf="data.entitlementCheck !== undefined"
                     [label]="'Entitlement check'"
-                    [value]="'Entitlement check is required.'"
-                    [shouldShowIndicator]="true">
+                    [value]="data.entitlementCheck ? 'Entitlement check is required.' : 'No'"
+                    [shouldShowIndicator]="data.entitlementCheck">
             </data-row>
 
-            <data-row-custom [label]="'Additional information'">
+            <data-row-custom
+                    [shouldHaveSeperator]="showAttemptNumber()||showPrn()"
+                    [label]="'Additional information'">
                 <div class="mes-data" *ngIf="data.previousCancellations.length === 0">- None</div>
                 <div class="mes-data" *ngIf="data.previousCancellations.length > 0">- Previous cancellations</div>
                 <div *ngFor="let previousCancellation of data.previousCancellations" class="mes-data">
@@ -57,6 +59,7 @@
             <data-row
                     *ngIf="showAttemptNumber()"
                     [label]="'Attempt number'"
+                    [shouldHaveSeperator]="false"
                     [value]="candidateDetails.attemptNumber">
             </data-row>
         </ion-grid>

--- a/src/app/pages/view-test-result/components/test-summary-card/test-summary-card.html
+++ b/src/app/pages/view-test-result/components/test-summary-card/test-summary-card.html
@@ -46,7 +46,7 @@
 
             <data-row [label]="'Conducted Language'" [value]="conductedLanguage"></data-row>
 
-            <data-row [label]="'Additional information'" [value]="additionalInformation"></data-row>
+            <data-row [label]="'Additional information'" [shouldHaveSeperator]="false" [value]="additionalInformation"></data-row>
         </ion-grid>
     </ion-card-content>
 </ion-card>

--- a/src/app/pages/view-test-result/components/vehicle-details-card/vehicle-details-card.html
+++ b/src/app/pages/view-test-result/components/vehicle-details-card/vehicle-details-card.html
@@ -20,6 +20,7 @@
 
             <data-row
                     *ngIf="registrationNumber"
+                    [shouldHaveSeperator]=" !!instructorRegistrationNumber || shouldShowDimensions || !!vehicleDetails"
                     [label]="'Vehicle registration number'"
                     [value]="registrationNumber">
             </data-row>
@@ -51,7 +52,7 @@
                         <ion-col *ngIf="shouldShowExtraDimensions" size="16">
                             <span class="mes-data"><span class="mes-data bold">H:</span> {{ vehicleHeight }}</span>
                         </ion-col>
-                        <ion-col *ngIf="shouldShowExtraDimensions" size="16">
+                        <ion-col *ngIf="shouldShowExtraDimensions" size="24">
                             <span class="mes-data"><span class="mes-data bold">Seats:</span> {{ numberOfSeats }}</span>
                         </ion-col>
                     </ion-row>
@@ -66,7 +67,7 @@
 
             <data-row *ngIf="isADI2()" [label]="'Training Records'" [value]="trainingRecords"></data-row>
 
-            <data-row *ngIf="displayVehicleDetails" [label]="'Vehicle Details'" [value]="schoolCarDualControls"></data-row>
+            <data-row *ngIf="displayVehicleDetails" [shouldHaveSeperator]="false" [label]="'Vehicle Details'" [value]="schoolCarDualControls"></data-row>
 
         </ion-grid>
     </ion-card-content>

--- a/src/app/pages/view-test-result/view-test-result.page.ts
+++ b/src/app/pages/view-test-result/view-test-result.page.ts
@@ -201,20 +201,29 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
   showDebriefCommonCard = (): boolean => isAnyOf(this.testCategory, [
     TestCategory.B, // Cat B
     TestCategory.BE, // Cat BE
-    TestCategory.EUAMM1, TestCategory.EUA1M1, TestCategory.EUA2M1, TestCategory.EUAM1,
-    TestCategory.C, TestCategory.C1, TestCategory.C1E, TestCategory.CE, // Cat C
-    TestCategory.D, TestCategory.D1, TestCategory.D1E, TestCategory.DE, // Cat D
+    TestCategory.EUAMM1, TestCategory.EUA1M1, TestCategory.EUA2M1, TestCategory.EUAM1, // Cat A Mod 1
+    TestCategory.EUAMM2, TestCategory.EUA1M2, TestCategory.EUA2M2, TestCategory.EUAM2, // Cat A Mod 2
+    TestCategory.C, TestCategory.C1, TestCategory.C1E, TestCategory.CE, // Cat C3B
+    TestCategory.CM, TestCategory.C1M, TestCategory.C1EM, TestCategory.CEM, // Cat C3A
+    TestCategory.D, TestCategory.D1, TestCategory.D1E, TestCategory.DE, // Cat D3B
+    TestCategory.DM, TestCategory.D1M, TestCategory.D1EM, TestCategory.DEM, // Cat D3A
     TestCategory.F, TestCategory.G, TestCategory.H, TestCategory.K, // Cat Home
+    TestCategory.ADI2, // ADI
+    TestCategory.CCPC, TestCategory.DCPC,
   ]);
 
   showVehicleDetailsCommonCard: () => boolean = () => isAnyOf(this.testCategory, [
     TestCategory.B, // Cat B
     TestCategory.BE, // Cat BE
+    TestCategory.EUAMM1, TestCategory.EUA1M1, TestCategory.EUA2M1, TestCategory.EUAM1, // Cat A Mod 1
+    TestCategory.EUAMM2, TestCategory.EUA1M2, TestCategory.EUA2M2, TestCategory.EUAM2, // Cat A Mod 2
     TestCategory.C, TestCategory.C1, TestCategory.C1E, TestCategory.CE, // Cat C 3B
     TestCategory.CM, TestCategory.C1M, TestCategory.C1EM, TestCategory.CEM, // Cat C 3A
     TestCategory.D, TestCategory.D1, TestCategory.D1E, TestCategory.DE, // Cat D 3B
     TestCategory.DM, TestCategory.D1M, TestCategory.D1EM, TestCategory.DEM, // Cat D 3A
     TestCategory.F, TestCategory.G, TestCategory.H, TestCategory.K, // Cat Home
+    TestCategory.ADI2, // ADI
+    TestCategory.CCPC, TestCategory.DCPC,
   ]);
 
   getDrivingFaultSumCount(): number {

--- a/src/app/pages/view-test-result/view-test-result.page.ts
+++ b/src/app/pages/view-test-result/view-test-result.page.ts
@@ -1,4 +1,7 @@
-import { Component, Input, OnInit } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component, Input, OnInit,
+} from '@angular/core';
 import { ModalController, Platform } from '@ionic/angular';
 import { BasePageComponent } from '@shared/classes/base-page';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
@@ -66,6 +69,7 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
     private loadingProvider: LoadingProvider,
     private faultCountProvider: FaultCountProvider,
     private faultSummaryProvider: FaultSummaryProvider,
+    private ref: ChangeDetectorRef,
   ) {
     super(platform, authenticationProvider, router);
   }
@@ -107,7 +111,13 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
   }
 
   handleLoadingUI = async (isLoading: boolean): Promise<void> => {
+    this.isLoading = isLoading;
+
     await this.loadingProvider.handleUILoading(isLoading, { spinner: 'circles' });
+
+    if (!isLoading) {
+      this.ref.detach();
+    }
   };
 
   getTestDetails(): TestDetailsModel {

--- a/src/app/providers/fault-summary/cat-manoeuvres/fault-summary.cat-manoeuvres.ts
+++ b/src/app/providers/fault-summary/cat-manoeuvres/fault-summary.cat-manoeuvres.ts
@@ -12,18 +12,27 @@ import { Manoeuvre } from '@dvsa/mes-test-schema/categories/common';
 export class FaultSummaryCatManoeuvreHelper {
 
   public static getSeriousFaultsNonTrailer(data: CatManoeuvreTestData): FaultSummary[] {
+    if (!data) {
+      return [];
+    }
     return [
       ...this.getManoeuvreFaultsCatManoeuvre(data.manoeuvres, CompetencyOutcome.S),
     ];
   }
 
   public static getDangerousFaultsNonTrailer(data: CatManoeuvreTestData): FaultSummary[] {
+    if (!data) {
+      return [];
+    }
     return [
       ...this.getManoeuvreFaultsCatManoeuvre(data.manoeuvres, CompetencyOutcome.D),
     ];
   }
 
   public static getSeriousFaultsTrailer(data: CatManoeuvreTestData): FaultSummary[] {
+    if (!data) {
+      return [];
+    }
     return [
       ...this.getManoeuvreFaultsCatManoeuvre(data.manoeuvres, CompetencyOutcome.S),
       ...this.getUncoupleRecoupleFault(data.uncoupleRecouple, CompetencyOutcome.S),
@@ -31,6 +40,9 @@ export class FaultSummaryCatManoeuvreHelper {
   }
 
   public static getDangerousFaultsTrailer(data: CatManoeuvreTestData): FaultSummary[] {
+    if (!data) {
+      return [];
+    }
     return [
       ...this.getManoeuvreFaultsCatManoeuvre(data.manoeuvres, CompetencyOutcome.D),
       ...this.getUncoupleRecoupleFault(data.uncoupleRecouple, CompetencyOutcome.D),


### PR DESCRIPTION
## Description
-Fixed a bug where the debrief section and faults would not display on a completed Cat A Mod 2, Cat C 3a and Cat D 3A test.
-Fixed a bug where the word "Seats" is spread across two lines in the vehicle details section.
-Fixed a bug where the Vehicle details section is not displayed in a completed Cat A Mod1 or Mod2 test.
-Fixed a bug where the colour of the 'Emergency Stop Avoidance' field in the Debrief section is a different colour to the rest of the text.
-Fixed a bug where the Debrief section and the Vehicle details section is not displayed on a completed ADI test.
-Fixed a bug where the Debrief section, the Vehicle details section, and the Assessment report field is not displayed in the test summary section of a completed CCPC or DCPC test
-Fixed a bug where the entitlement check field is not displayed in the test details section.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
