### PR TITLE
mes-7105 bugFixes

### DIFF
--- a/src/app/pages/test-results-search/components/search-result/search-result.html
+++ b/src/app/pages/test-results-search/components/search-result/search-result.html
@@ -15,7 +15,7 @@
             <ion-col class="ion-no-padding">
                 <h3 id="search-result-name-label">{{getName()}}</h3>
             </ion-col>
-            <ion-col size="14" class="ion-no-padding">
+            <ion-col size="18" class="ion-no-padding">
                 <h2 id="search-result-category-label">{{searchResult.category}}</h2>
             </ion-col>
             <ion-col size="10" class="ion-no-padding ion-padding-end">

--- a/src/app/pages/view-test-result/view-test-result.page.html
+++ b/src/app/pages/view-test-result/view-test-result.page.html
@@ -64,6 +64,19 @@
                 [delegatedTest]="testResult['delegatedTest']">
         </debrief-card>
 
+        <cpc-debrief-card
+                *ngIf="testResult.testData['combination'] && showCPCDebriefCommonCard()"
+                [isDetailedTestView]="true"
+                [testOutcome]="getHeaderDetails()?.testOutcome"
+                [question1]="testResult.testData['question1']"
+                [question2]="testResult.testData['question2']"
+                [question3]="testResult.testData['question3']"
+                [question4]="testResult.testData['question4']"
+                [question5]="testResult.testData['question5']"
+                [overallScore]="testResult.testData['totalPercent']"
+                [combination]="testResult.testData['combination']"
+        ></cpc-debrief-card>
+
         <test-summary-card
                 [accompaniment]="testResult.accompaniment"
                 [passCompletion]="testResult.passCompletion"

--- a/src/app/pages/view-test-result/view-test-result.page.ts
+++ b/src/app/pages/view-test-result/view-test-result.page.ts
@@ -219,6 +219,9 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
     TestCategory.DM, TestCategory.D1M, TestCategory.D1EM, TestCategory.DEM, // Cat D3A
     TestCategory.F, TestCategory.G, TestCategory.H, TestCategory.K, // Cat Home
     TestCategory.ADI2, // ADI
+  ]);
+
+  showCPCDebriefCommonCard = (): boolean => isAnyOf(this.testCategory, [
     TestCategory.CCPC, TestCategory.DCPC,
   ]);
 


### PR DESCRIPTION
## Description
Fixed a bug where the incorrect debrief card was displaying for CPC type tests.
Fixed a bug where CPC type categories would take up more than one line on the search results.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="697" alt="image" src="https://user-images.githubusercontent.com/88314925/162938665-b5e35b31-4359-47ac-b7af-5aff01d47a66.png">
<img width="708" alt="image" src="https://user-images.githubusercontent.com/88314925/162938724-d76a6a89-5daa-4a3c-a1f4-054157613677.png">
