### PR TITLE
mes-7236 - acticity code analytics

### DIFF
--- a/src/app/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
+++ b/src/app/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
@@ -4,6 +4,9 @@ import { StoreModel } from '@shared/models/store.model';
 import { ActivityCodes } from '@shared/models/activity-codes';
 import { SetActivityCode } from '@store/tests/activity-code/activity-code.actions';
 import { Router } from '@angular/router';
+import {
+  WaitingRoomToCarReportActivityCode,
+} from '@pages/waiting-room-to-car/waiting-room-to-car.actions';
 
 @Component({
   selector: 'eyesight-failure-confirmation',
@@ -30,5 +33,6 @@ export class EyesightFailureConfirmationComponent {
   onContinue(): void {
     this.router.navigate([this.nextPageOnFail]);
     this.store$.dispatch(SetActivityCode(ActivityCodes.FAIL_EYESIGHT));
+    this.store$.dispatch(WaitingRoomToCarReportActivityCode(ActivityCodes.FAIL_EYESIGHT));
   }
 }

--- a/src/app/pages/waiting-room-to-car/waiting-room-to-car.actions.ts
+++ b/src/app/pages/waiting-room-to-car/waiting-room-to-car.actions.ts
@@ -1,4 +1,5 @@
 import { createAction } from '@ngrx/store';
+import { ActivityCode } from '@dvsa/mes-test-schema/categories/common';
 
 export const WaitingRoomToCarViewBikeCategoryModal = createAction(
   '[WaitingRoomToCarPage] Waiting Room To Car View Bike Category Modal',
@@ -26,4 +27,9 @@ export const WaitingRoomToCarBikeCategorySelected = createAction(
 export const WaitingRoomToCarBikeCategoryChanged = createAction(
   '[WaitingRoomToCarPage] Waiting Room To Car Bike Category Changed',
   (initialBikeCategory: string, selectedBikeCategory: string) => ({ initialBikeCategory, selectedBikeCategory }),
+);
+
+export const WaitingRoomToCarReportActivityCode = createAction(
+  '[WaitingRoomToCarPage] Waiting Room To Car report activity code',
+  (activityCode: ActivityCode) => ({ activityCode }),
 );

--- a/src/app/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
+++ b/src/app/pages/waiting-room-to-car/waiting-room-to-car.analytics.effects.ts
@@ -17,6 +17,7 @@ import {
   WaitingRoomToCarBikeCategoryChanged,
   WaitingRoomToCarBikeCategorySelected,
   WaitingRoomToCarError,
+  WaitingRoomToCarReportActivityCode,
   WaitingRoomToCarValidationError,
   WaitingRoomToCarViewBikeCategoryModal,
   WaitingRoomToCarViewDidEnter,
@@ -36,6 +37,8 @@ import {
 } from '@store/tests/journal-data/common/application-reference/application-reference.selector';
 import { getTestCategory } from '@store/tests/category/category.reducer';
 import { formatAnalyticsText } from '@shared/helpers/format-analytics-text';
+import { getEnumKeyByValue } from '@shared/helpers/enum-keys';
+import { ActivityCodes } from '@shared/models/activity-codes';
 
 @Injectable()
 export class WaitingRoomToCarAnalyticsEffects {
@@ -203,6 +206,29 @@ export class WaitingRoomToCarAnalyticsEffects {
         formatAnalyticsText(AnalyticsEventCategories.WAITING_ROOM_TO_CAR, tests),
         formatAnalyticsText(AnalyticsEvents.BIKE_CATEGORY_MODAL_TRIGGERED, tests),
         'bike category selection modal triggered',
+      );
+      return of(AnalyticRecorded());
+    }),
+  ));
+
+  waitingRoomToCarReportActivityCode$ = createEffect(() => this.actions$.pipe(
+    ofType(
+      WaitingRoomToCarReportActivityCode,
+    ),
+    concatMap((action) => of(action).pipe(
+      withLatestFrom(
+        this.store$.pipe(
+          select(getTests),
+        ),
+      ),
+    )),
+    concatMap(([{ activityCode }, tests]:
+    [ReturnType <typeof WaitingRoomToCarReportActivityCode>, TestsModel]) => {
+      const [description, code] = getEnumKeyByValue(ActivityCodes, activityCode);
+      this.analytics.logEvent(
+        formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
+        formatAnalyticsText(AnalyticsEvents.SET_ACTIVITY_CODE, tests),
+        `${code} - ${description}`,
       );
       return of(AnalyticRecorded());
     }),


### PR DESCRIPTION
## Description

added analytic effect for submitting activity code when set for an eyesight failure as eyesight failures bypass the pass/non pass finilisation screens.

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
