### PR TITLE
mes-8015-Emergency Stop Modal Fix

### DIFF
--- a/src/app/providers/test-report-validator/test-report-validator.ts
+++ b/src/app/providers/test-report-validator/test-report-validator.ts
@@ -183,17 +183,17 @@ export class TestReportValidatorProvider {
 
       if (avoidanceNotMet === CompetencyOutcome.S) {
         if (avoidanceFirstAttempt === undefined || avoidanceSecondAttempt === undefined) {
-          if (emergencyStopFirstAttempt === undefined) {
-            return SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING;
-          }
+          // if (emergencyStopFirstAttempt === undefined) {
+          //   return SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING;
+          // }
           return SpeedCheckState.AVOIDANCE_MISSING;
         }
         return SpeedCheckState.NOT_MET;
       }
       if (emergencyStopFirstAttempt === undefined || emergencyStopSecondAttempt === undefined) {
-        if (avoidanceFirstAttempt === undefined) {
-          return SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING;
-        }
+        // if (avoidanceFirstAttempt === undefined) {
+        //   return SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING;
+        // }
         return SpeedCheckState.EMERGENCY_STOP_MISSING;
       }
       return SpeedCheckState.NOT_MET;

--- a/src/app/providers/test-report-validator/test-report-validator.ts
+++ b/src/app/providers/test-report-validator/test-report-validator.ts
@@ -183,17 +183,11 @@ export class TestReportValidatorProvider {
 
       if (avoidanceNotMet === CompetencyOutcome.S) {
         if (avoidanceFirstAttempt === undefined || avoidanceSecondAttempt === undefined) {
-          // if (emergencyStopFirstAttempt === undefined) {
-          //   return SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING;
-          // }
           return SpeedCheckState.AVOIDANCE_MISSING;
         }
         return SpeedCheckState.NOT_MET;
       }
       if (emergencyStopFirstAttempt === undefined || emergencyStopSecondAttempt === undefined) {
-        // if (avoidanceFirstAttempt === undefined) {
-        //   return SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING;
-        // }
         return SpeedCheckState.EMERGENCY_STOP_MISSING;
       }
       return SpeedCheckState.NOT_MET;

--- a/src/app/providers/test-report-validator/test-report-validator.ts
+++ b/src/app/providers/test-report-validator/test-report-validator.ts
@@ -188,9 +188,6 @@ export class TestReportValidatorProvider {
           }
           return SpeedCheckState.AVOIDANCE_MISSING;
         }
-        if (emergencyStopFirstAttempt === undefined) {
-          return SpeedCheckState.EMERGENCY_STOP_MISSING;
-        }
         return SpeedCheckState.NOT_MET;
       }
       if (emergencyStopFirstAttempt === undefined || emergencyStopSecondAttempt === undefined) {
@@ -198,9 +195,6 @@ export class TestReportValidatorProvider {
           return SpeedCheckState.EMERGENCY_STOP_AND_AVOIDANCE_MISSING;
         }
         return SpeedCheckState.EMERGENCY_STOP_MISSING;
-      }
-      if (avoidanceFirstAttempt === undefined) {
-        return SpeedCheckState.AVOIDANCE_MISSING;
       }
       return SpeedCheckState.NOT_MET;
     }


### PR DESCRIPTION
## Description
fixed the wrong modal appearing during certain conditions on a speed check
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="715" alt="Speed requirement" src="https://user-images.githubusercontent.com/88314925/176643278-59cfeef6-e3db-466a-9184-7c431370256e.png">
<img width="427" alt="Speed requirements not met" src="https://user-images.githubusercontent.com/88314925/176643315-8a318212-36a0-4b58-9aa1-8971271223fc.png">
<img width="709" alt="First Second" src="https://user-images.githubusercontent.com/88314925/176643339-4cc5820a-0728-444b-a0a9-124605877300.png">
<img width="425" alt="You've not completed the" src="https://user-images.githubusercontent.com/88314925/176643364-0a252597-d859-4c6a-810a-ec068016fe56.png">
