### PR TITLE
mes-8140: comms page privacy message - adi3

### DIFF
--- a/src/app/pages/communication/communication.page.html
+++ b/src/app/pages/communication/communication.page.html
@@ -25,7 +25,10 @@
 
       <div class="mes-full-width-card-separator"></div>
 
-      <privacy-notice [language]="pageState.conductedLanguage$ | async"></privacy-notice>
+      <privacy-notice
+              [language]="pageState.conductedLanguage$ | async"
+              [category]="pageState.testCategory$ | async"
+      ></privacy-notice>
 
       <div class="mes-full-width-card" id="declaration-section">
 

--- a/src/app/pages/communication/components/privacy-notice/__tests__/privacy-notice.spec.ts
+++ b/src/app/pages/communication/components/privacy-notice/__tests__/privacy-notice.spec.ts
@@ -3,6 +3,7 @@ import { IonicModule } from '@ionic/angular';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { configureTestSuite } from 'ng-bullet';
 import { translateServiceMock } from '@shared/helpers/__mocks__/translate.mock';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { PrivacyNoticeComponent } from '../privacy-notice';
 
 describe('PrivacyNoticeComponent', () => {
@@ -32,6 +33,27 @@ describe('PrivacyNoticeComponent', () => {
   describe('Class', () => {
     it('should compile', () => {
       expect(component).toBeDefined();
+    });
+
+    describe('categorySpecificTestContext', () => {
+      it('return adi when adi', () => {
+        expect(component.categorySpecificTestContext(TestCategory.ADI3)).toEqual('ADI');
+      });
+
+      it('return common.riding when when bike test', () => {
+        expect(component.categorySpecificTestContext(TestCategory.EUA1M1)).toEqual('common.riding');
+        expect(component.categorySpecificTestContext(TestCategory.EUA1M2)).toEqual('common.riding');
+        expect(component.categorySpecificTestContext(TestCategory.EUA2M1)).toEqual('common.riding');
+        expect(component.categorySpecificTestContext(TestCategory.EUA2M2)).toEqual('common.riding');
+        expect(component.categorySpecificTestContext(TestCategory.EUAM1)).toEqual('common.riding');
+        expect(component.categorySpecificTestContext(TestCategory.EUAM2)).toEqual('common.riding');
+        expect(component.categorySpecificTestContext(TestCategory.EUAMM1)).toEqual('common.riding');
+        expect(component.categorySpecificTestContext(TestCategory.EUAMM2)).toEqual('common.riding');
+      });
+
+      it('return common.driving when not adi or bike test', () => {
+        expect(component.categorySpecificTestContext(TestCategory.B)).toEqual('common.driving');
+      });
     });
   });
 

--- a/src/app/pages/communication/components/privacy-notice/privacy-notice.html
+++ b/src/app/pages/communication/components/privacy-notice/privacy-notice.html
@@ -7,7 +7,7 @@
             <ion-col size="83">
                 <p class="privacy-text">
                     {{'communication.privacyNotice' | translate:{
-                        drivingOrRiding: isRider ? ('common.riding' | translate) : ('common.driving' | translate)}
+                        testSpecificMessage: (categorySpecificTestContext(category)| translate)}
                     }}
                 </p>
             </ion-col>

--- a/src/app/pages/communication/components/privacy-notice/privacy-notice.ts
+++ b/src/app/pages/communication/components/privacy-notice/privacy-notice.ts
@@ -3,6 +3,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { configureI18N } from '@shared/helpers/translation.helpers';
 import { Language } from '@store/tests/communication-preferences/communication-preferences.model';
 import { CategoryCode } from '@dvsa/mes-test-schema/categories/common';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 @Component({
   selector: 'privacy-notice',
@@ -25,16 +26,16 @@ export class PrivacyNoticeComponent implements OnInit {
 
   categorySpecificTestContext(cat: CategoryCode): string {
     switch (cat) {
-      case 'ADI3':
+      case TestCategory.ADI3:
         return 'ADI';
-      case 'EUA1M1':
-      case 'EUA1M2':
-      case 'EUA2M1':
-      case 'EUA2M2':
-      case 'EUAM1':
-      case 'EUAM2':
-      case 'EUAMM1':
-      case 'EUAMM2':
+      case TestCategory.EUA1M1:
+      case TestCategory.EUA1M2:
+      case TestCategory.EUA2M1:
+      case TestCategory.EUA2M2:
+      case TestCategory.EUAM1:
+      case TestCategory.EUAM2:
+      case TestCategory.EUAMM1:
+      case TestCategory.EUAMM2:
         return 'common.riding';
       default:
         return 'common.driving';

--- a/src/app/pages/communication/components/privacy-notice/privacy-notice.ts
+++ b/src/app/pages/communication/components/privacy-notice/privacy-notice.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { configureI18N } from '@shared/helpers/translation.helpers';
 import { Language } from '@store/tests/communication-preferences/communication-preferences.model';
+import { CategoryCode } from '@dvsa/mes-test-schema/categories/common';
 
 @Component({
   selector: 'privacy-notice',
@@ -14,12 +15,30 @@ export class PrivacyNoticeComponent implements OnInit {
   language: Language;
 
   @Input()
-  isRider: boolean = false;
+  category: CategoryCode;
 
   constructor(private translate: TranslateService) { }
 
   ngOnInit() : void {
     configureI18N(this.language, this.translate);
+  }
+
+  categorySpecificTestContext(cat: CategoryCode): string {
+    switch (cat) {
+      case 'ADI3':
+        return 'ADI';
+      case 'EUA1M1':
+      case 'EUA1M2':
+      case 'EUA2M1':
+      case 'EUA2M2':
+      case 'EUAM1':
+      case 'EUAM2':
+      case 'EUAMM1':
+      case 'EUAMM2':
+        return 'common.riding';
+      default:
+        return 'common.driving';
+    }
   }
 
 }

--- a/src/assets/i18n/cy.json
+++ b/src/assets/i18n/cy.json
@@ -17,7 +17,7 @@
     "newEmailLabel": "Trwy e-bost (newid e-bost)",
     "newEmailValidation": "Nodwch e-bost dilys",
     "title": "Datganiad",
-    "privacyNotice": "Rwy'n cytuno i DVSA gasglu, defnyddio, storio a rhannu fy ngwybodaeth bersonol at ddibenion cynnal y prawf {{drivingOrRiding}}"
+    "privacyNotice": "Rwy'n cytuno i DVSA gasglu, defnyddio, storio a rhannu fy ngwybodaeth bersonol at ddibenion cynnal y prawf {{testSpecificMessage}}"
   },
   "debrief": {
     "safetyAndBalanceQuestions": {

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -17,7 +17,7 @@
     "newEmailLabel": "By email (new email)",
     "newEmailValidation": "Please enter a valid email",
     "title": "Declaration",
-    "privacyNotice": "I agree to DVSA collecting, using, storing and sharing my personal information for the purpose of carrying out the {{drivingOrRiding}} test."
+    "privacyNotice": "I agree to DVSA collecting, using, storing and sharing my personal information for the purpose of carrying out the {{testSpecificMessage}} test."
   },
   "debrief": {
     "safetyAndBalanceQuestions": {


### PR DESCRIPTION
## Description

addition logic to change privacy message based upon test type

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="533" alt="Screenshot 2022-07-21 at 11 11 01" src="https://user-images.githubusercontent.com/48550267/180192447-828191a7-1bc3-4757-8096-1f36cb8020fb.png">
<img width="539" alt="Screenshot 2022-07-21 at 11 11 29" src="https://user-images.githubusercontent.com/48550267/180192455-59056db9-b3a7-4caf-b411-75fbe6e3cd4a.png">
<img width="560" alt="Screenshot 2022-07-21 at 11 11 42" src="https://user-images.githubusercontent.com/48550267/180192458-de91f8e7-d70d-4635-bce4-98058b1f672e.png">

