### PR TITLE
mes-8186-EStopAvoidanceDisplay

### DIFF
--- a/src/app/pages/view-test-result/components/debrief-card/debrief-card.html
+++ b/src/app/pages/view-test-result/components/debrief-card/debrief-card.html
@@ -53,7 +53,8 @@
 
             <data-row
                     [label]="'ETA'"
-                    [value]="eTA">
+                    [value]="eTA"
+                    [shouldHaveSeperator]="!(data['emergencyStop'] || data['avoidance'])">
             </data-row>
 
             <vehicle-checks-data-row

--- a/src/app/pages/view-test-result/components/speed-card/speed-card.html
+++ b/src/app/pages/view-test-result/components/speed-card/speed-card.html
@@ -1,6 +1,6 @@
 <ion-row [ngClass]="shouldHaveSeperator ? 'mes-data-row-with-separator': 'mes-data-row'">
     <ion-grid>
-        <ion-row>
+        <ion-row *ngIf="emergencyStop && (emergencyStop.firstAttempt || emergencyStop.secondAttempt)">
             <ion-col size="40">
                 <label>Emergency Stop</label>
             </ion-col>
@@ -30,7 +30,7 @@
             </ion-col>
         </ion-row>
 
-        <ion-row>
+        <ion-row *ngIf="avoidance && (avoidance.firstAttempt || avoidance.secondAttempt)">
             <ion-col size="40">
                 <label>Avoidance</label>
             </ion-col>


### PR DESCRIPTION
## Description
Changed debrief card to not show emergency stop or avoidance if it's not present

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="723" alt="image" src="https://user-images.githubusercontent.com/88314925/187721612-7314c18c-d6ab-4264-bff0-5ac02606d111.png">
