### PR TITLE
mes-8435-terminationSafetyQuestion

### DIFF
--- a/src/app/pages/debrief/debrief.page.html
+++ b/src/app/pages/debrief/debrief.page.html
@@ -61,7 +61,7 @@
 
 
     <ion-card
-            *ngIf="isCatD()">
+            *ngIf="isCatD() && pageState.showSafetyQuestions$ | async">
         <safety-question-data-row
                 [label]="'Safety question(s)'"
                 [data]="pageState.safetyQuestions$ | async"

--- a/src/app/pages/debrief/debrief.page.ts
+++ b/src/app/pages/debrief/debrief.page.ts
@@ -105,7 +105,8 @@ interface DebriefPageState {
   showSafetyAndBalance$: Observable<boolean>;
   grade$: Observable<string>;
   immediateDanger$: Observable<boolean>;
-  safetyQuestions$: Observable<SafetyQuestionResult[]>
+  safetyQuestions$: Observable<SafetyQuestionResult[]>;
+  showSafetyQuestions$: Observable<boolean>;
 }
 
 @Component({
@@ -292,6 +293,16 @@ export class DebriefPage extends PracticeableBasePageComponent {
         map((category) => isAnyOf(category, [
           TestCategory.EUAMM1, TestCategory.EUA1M1, TestCategory.EUA2M1, TestCategory.EUAM1,
         ])),
+      ),
+      showSafetyQuestions$: currentTest$.pipe(
+        withLatestFrom(testCategory$),
+        filter(([, category]) => isAnyOf(category, [
+          TestCategory.D, TestCategory.D1, TestCategory.DE, TestCategory.D1E,
+        ])),
+        map(([data, category]) => this.testDataByCategoryProvider.getTestDataByCategoryCode(category)(data)),
+        select(getSafetyQuestionsCatD),
+        select(getSafetyQuestions),
+        map((questions) => questions.some((question) => question.outcome)),
       ),
       showSafetyAndBalance$: currentTest$.pipe(
         select(getTestCategory),

--- a/src/app/pages/view-test-result/components/safety-question-data-row/safety-question-data-row.ts
+++ b/src/app/pages/view-test-result/components/safety-question-data-row/safety-question-data-row.ts
@@ -22,6 +22,6 @@ export class SafetyDataRowComponent {
   isDebrief: boolean = false;
 
   public shouldShowFault(outcome: QuestionOutcome): boolean {
-    return outcome === CompetencyOutcome.DF;
+    return outcome === CompetencyOutcome.DF || outcome === undefined;
   }
 }


### PR DESCRIPTION
## Description
Fixed an error where an undefined safety question answer will result in the 'correct' icon being shown on the debrief page.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
