### PR TITLE
MES-7676 / GearboxCategory event duplication

### DIFF
--- a/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
+++ b/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
@@ -12,7 +12,6 @@ import {
 } from '@providers/analytics/analytics.model';
 import { AnalyticNotRecorded, AnalyticRecorded } from '@providers/analytics/analytics.actions';
 import * as testsActions from '@store/tests/tests.actions';
-import * as vehicleDetailsActions from '@store/tests/vehicle-details/vehicle-details.actions';
 import * as testSummaryActions from '@store/tests/test-summary/test-summary.actions';
 import * as commsActions from '@store/tests/communication-preferences/communication-preferences.actions';
 import { testsReducer } from '@store/tests/tests.reducer';
@@ -23,7 +22,6 @@ import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/
 import { Language } from '@store/tests/communication-preferences/communication-preferences.model';
 import { SetActivityCode } from '@store/tests/activity-code/activity-code.actions';
 import { ActivityCodes } from '@shared/models/activity-codes';
-import { TransmissionType } from '@shared/models/transmission-type';
 import { StoreModel } from '@shared/models/store.model';
 import * as nonPassFinalisationActions from '../non-pass-finalisation.actions';
 import { NonPassFinalisationAnalyticsEffects } from '../non-pass-finalisation.analytics.effects';

--- a/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
+++ b/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.analytics.effects.spec.ts
@@ -124,60 +124,6 @@ describe('NonPassFinalisationAnalyticsEffects', () => {
       });
     });
   });
-  describe('transmissionChanged$', () => {
-    it('should call logEvent with Manual if Gearbox Category is Manual', (done) => {
-      // ARRANGE
-      store$.dispatch(testsActions.StartTest(123, TestCategory.C));
-      store$.dispatch(PopulateCandidateDetails(candidateMock));
-      store$.dispatch(SetActivityCode(ActivityCodes.PASS));
-      // ACT
-      actions$.next(vehicleDetailsActions.GearboxCategoryChanged(TransmissionType.Manual));
-      // ASSERT
-      effects.transmissionChanged$.subscribe((result) => {
-        expect(result.type === AnalyticRecorded.type).toBe(true);
-        expect(analyticsProviderMock.logEvent)
-          .toHaveBeenCalledWith(
-            AnalyticsEventCategories.POST_TEST,
-            AnalyticsEvents.GEARBOX_CATEGORY_CHANGED,
-            TransmissionType.Manual,
-          );
-        done();
-      });
-    });
-    it('should call logEvent with Automatic if Gearbox Category is Automatic', (done) => {
-      // ARRANGE
-      store$.dispatch(testsActions.StartTest(123, TestCategory.C));
-      store$.dispatch(PopulateCandidateDetails(candidateMock));
-      store$.dispatch(SetActivityCode(ActivityCodes.PASS));
-      // ACT
-      actions$.next(vehicleDetailsActions.GearboxCategoryChanged(TransmissionType.Automatic));
-      // ASSERT
-      effects.transmissionChanged$.subscribe((result) => {
-        expect(result.type === AnalyticRecorded.type).toBe(true);
-        expect(analyticsProviderMock.logEvent)
-          .toHaveBeenCalledWith(
-            AnalyticsEventCategories.POST_TEST,
-            AnalyticsEvents.GEARBOX_CATEGORY_CHANGED,
-            TransmissionType.Automatic,
-          );
-        done();
-      });
-    });
-    it('should not call logEvent if there is no activity code', (done) => {
-      // ARRANGE
-      store$.dispatch(testsActions.StartTest(123, TestCategory.C));
-      store$.dispatch(PopulateCandidateDetails(candidateMock));
-      store$.dispatch(SetActivityCode(null));
-      // ACT
-      actions$.next(vehicleDetailsActions.GearboxCategoryChanged(TransmissionType.Manual));
-      // ASSERT
-      effects.transmissionChanged$.subscribe((result) => {
-        expect(result.type === AnalyticNotRecorded.type).toBe(true);
-        expect(analyticsProviderMock.logEvent).not.toHaveBeenCalled();
-        done();
-      });
-    });
-  });
   describe('d255Yes', () => {
     it('should call logEvent', (done) => {
       // ARRANGE

--- a/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
+++ b/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
@@ -19,7 +19,6 @@ import { getTests } from '@store/tests/tests.reducer';
 import { getActivityCode } from '@store/tests/activity-code/activity-code.reducer';
 import { TestsModel } from '@store/tests/tests.model';
 import { Language } from '@store/tests/communication-preferences/communication-preferences.model';
-import * as vehicleDetailsActions from '@store/tests/vehicle-details/vehicle-details.actions';
 import * as testSummaryActions from '@store/tests/test-summary/test-summary.actions';
 import * as commsActions from '@store/tests/communication-preferences/communication-preferences.actions';
 import { D255No, D255Yes } from '@store/tests/test-summary/test-summary.actions';

--- a/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
+++ b/src/app/pages/non-pass-finalisation/non-pass-finalisation.analytics.effects.ts
@@ -84,34 +84,6 @@ export class NonPassFinalisationAnalyticsEffects {
     }),
   ));
 
-  transmissionChanged$ = createEffect(() => this.actions$.pipe(
-    ofType(vehicleDetailsActions.GearboxCategoryChanged),
-    concatMap((action) => of(action).pipe(
-      withLatestFrom(
-        this.store$.pipe(
-          select(getTests),
-        ),
-        this.store$.pipe(
-          select(getTests),
-          select(getCurrentTest),
-          select(getActivityCode),
-        ),
-      ),
-    )),
-    concatMap(([action, tests, activityCode]:
-    [ReturnType<typeof vehicleDetailsActions.GearboxCategoryChanged>, TestsModel, ActivityCode]) => {
-      if (activityCode) {
-        this.analytics.logEvent(
-          formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
-          formatAnalyticsText(AnalyticsEvents.GEARBOX_CATEGORY_CHANGED, tests),
-          action.gearboxCategory,
-        );
-        return of(AnalyticRecorded());
-      }
-      return of(AnalyticNotRecorded());
-    }),
-  ));
-
   d255Yes$ = createEffect(() => this.actions$.pipe(
     ofType(testSummaryActions.D255Yes),
     concatMap((action) => of(action).pipe(

--- a/src/app/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
+++ b/src/app/pages/pass-finalisation/__tests__/pass-finalisation.analytics.effects.spec.ts
@@ -26,6 +26,8 @@ import { AnalyticRecorded, AnalyticNotRecorded } from '@providers/analytics/anal
 import { StoreModel } from '@shared/models/store.model';
 import { AnalyticsProviderMock } from '@providers/analytics/__mocks__/analytics.mock';
 import { AnalyticsProvider } from '@providers/analytics/analytics';
+import { Router } from '@angular/router';
+import { CAT_B } from '@pages/page-names.constants';
 import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
 import * as passFinalisationActions from '../pass-finalisation.actions';
 import { PassFinalisationAnalyticsEffects } from '../pass-finalisation.analytics.effects';
@@ -49,6 +51,7 @@ describe('PassFinalisationAnalyticsEffects', () => {
       providers: [
         PassFinalisationAnalyticsEffects,
         { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        { provide: Router, useValue: { url: `/${CAT_B.PASS_FINALISATION_PAGE}` } },
         provideMockActions(() => actions$),
         Store,
       ],
@@ -58,6 +61,7 @@ describe('PassFinalisationAnalyticsEffects', () => {
     effects = TestBed.inject(PassFinalisationAnalyticsEffects);
     analyticsProviderMock = TestBed.inject(AnalyticsProvider);
     store$ = TestBed.inject(Store);
+
     spyOn(analyticsProviderMock, 'logEvent');
   }));
 

--- a/src/app/pages/pass-finalisation/pass-finalisation.analytics.effects.ts
+++ b/src/app/pages/pass-finalisation/pass-finalisation.analytics.effects.ts
@@ -37,6 +37,7 @@ import {
   getFurtherDevelopment,
   getReasonForNoAdviceGiven,
 } from '@store/tests/test-data/cat-adi-part3/review/review.selector';
+import { Router } from '@angular/router';
 import { getTestData } from '@store/tests/test-data/cat-b/test-data.reducer';
 import {
   PassFinalisationViewDidEnter,
@@ -46,10 +47,13 @@ import {
 @Injectable()
 export class PassFinalisationAnalyticsEffects {
 
+  private classPrefix: string = '/PassFinalisation';
+
   constructor(
     public analytics: AnalyticsProvider,
     private actions$: Actions,
     private store$: Store<StoreModel>,
+    private router: Router,
   ) {
   }
 
@@ -180,7 +184,8 @@ export class PassFinalisationAnalyticsEffects {
     )),
     concatMap(([action, tests, activityCode]:
     [ReturnType<typeof vehicleDetailsActions.GearboxCategoryChanged>, TestsModel, ActivityCode]) => {
-      if (activityCode != null) {
+      // Check current URL begins with PassFin prefix before recording analytic to stop duplicated events.
+      if (activityCode != null && this.router.url?.startsWith(this.classPrefix)) {
         this.analytics.logEvent(
           formatAnalyticsText(AnalyticsEventCategories.POST_TEST, tests),
           formatAnalyticsText(AnalyticsEvents.GEARBOX_CATEGORY_CHANGED, tests),

--- a/src/app/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
+++ b/src/app/pages/waiting-room-to-car/__tests__/waiting-room-to-car.analytics.effects.spec.ts
@@ -29,6 +29,8 @@ import {
   PDILogbook,
   TraineeLicence,
 } from '@store/tests/trainer-details/cat-adi-part3/trainer-details.cat-adi-part3.actions';
+import { Router } from '@angular/router';
+import { CAT_B } from '@pages/page-names.constants';
 import { WaitingRoomToCarAnalyticsEffects } from '../waiting-room-to-car.analytics.effects';
 import * as waitingRoomToCarActions from '../waiting-room-to-car.actions';
 import * as fakeJournalActions from '../../fake-journal/fake-journal.actions';
@@ -56,6 +58,7 @@ describe('WaitingRoomToCarAnalyticsEffects', () => {
       providers: [
         WaitingRoomToCarAnalyticsEffects,
         { provide: AnalyticsProvider, useClass: AnalyticsProviderMock },
+        { provide: Router, useValue: { url: `/${CAT_B.WAITING_ROOM_TO_CAR_PAGE}` } },
         provideMockActions(() => actions$),
         Store,
       ],


### PR DESCRIPTION
## Description
- Add guards to stop duplication of GearboxCategory actions
## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
