### PR TITLE
Mes 8658 code5 fail

### DIFF
--- a/src/app/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
+++ b/src/app/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
@@ -36,8 +36,17 @@ describe('ActivityCodeFinalisationProvider', () => {
     });
 
     it('should call testResultProvider with the correct category for C', () => {
-      activityCodeFinalisationProvider.catCTestDataIsInvalid(ActivityCodes.FAIL_CANDIDATE_STOPS_TEST, {});
+      activityCodeFinalisationProvider.catCTestDataIsInvalid(
+        ActivityCodes.FAIL_CANDIDATE_STOPS_TEST, {}, TestCategory.C,
+      );
       expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.C, {});
+    });
+
+    it('should call testResultProvider with the correct category for CE', () => {
+      activityCodeFinalisationProvider.catCTestDataIsInvalid(
+        ActivityCodes.FAIL_CANDIDATE_STOPS_TEST, {}, TestCategory.CE,
+      );
+      expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.CE, {});
     });
 
     it('should call testResultProvider with the correct category for CM', () => {
@@ -80,7 +89,7 @@ describe('ActivityCodeFinalisationProvider', () => {
     });
     it('should return false when activity code is not 4/5 for C', async () => {
       const result = await activityCodeFinalisationProvider
-        .catCTestDataIsInvalid(ActivityCodes.EXAMINER_ILL_PRE_TEST, {});
+        .catCTestDataIsInvalid(ActivityCodes.EXAMINER_ILL_PRE_TEST, {}, TestCategory.C);
       expect(result).toBe(false);
     });
     it('should return false when activity code is not 4/5 for D', async () => {

--- a/src/app/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
+++ b/src/app/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
@@ -31,7 +31,9 @@ describe('ActivityCodeFinalisationProvider', () => {
     });
 
     it('should call testResultProvider with the correct category for B', () => {
-      activityCodeFinalisationProvider.catBTestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
+      activityCodeFinalisationProvider.catBTestDataIsInvalid(
+        ActivityCodes.FAIL_PUBLIC_SAFETY, {}, TestCategory.B,
+      );
       expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.B, {});
     });
 
@@ -50,27 +52,45 @@ describe('ActivityCodeFinalisationProvider', () => {
     });
 
     it('should call testResultProvider with the correct category for CM', () => {
-      activityCodeFinalisationProvider.catManoeuvresTestDataIsInvalid(ActivityCodes.FAIL_CANDIDATE_STOPS_TEST, {});
+      activityCodeFinalisationProvider.catManoeuvresTestDataIsInvalid(
+        ActivityCodes.FAIL_CANDIDATE_STOPS_TEST, {}, TestCategory.CM,
+      );
       expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.CM, {});
     });
 
     it('should call testResultProvider with the correct category for AM1', () => {
-      activityCodeFinalisationProvider.catAMod1TestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
+      activityCodeFinalisationProvider.catAMod1TestDataIsInvalid(
+        ActivityCodes.FAIL_PUBLIC_SAFETY,
+        {},
+        TestCategory.EUAM1,
+      );
       expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.EUAM1, {});
     });
 
     it('should call testResultProvider with the correct category for AM2', () => {
-      activityCodeFinalisationProvider.catAMod2TestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
+      activityCodeFinalisationProvider.catAMod2TestDataIsInvalid(
+        ActivityCodes.FAIL_PUBLIC_SAFETY,
+        {},
+        TestCategory.EUAM2,
+      );
       expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.EUAM2, {});
     });
 
     it('should call testResultProvider with the correct category for ADI2', () => {
-      activityCodeFinalisationProvider.catADIPart2TestDataIsInvalid(ActivityCodes.FAIL_CANDIDATE_STOPS_TEST, {});
+      activityCodeFinalisationProvider.catADIPart2TestDataIsInvalid(
+        ActivityCodes.FAIL_CANDIDATE_STOPS_TEST,
+        {},
+        TestCategory.ADI2,
+      );
       expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.ADI2, {});
     });
 
     it('should call testResultProvider with the correct category for Home', () => {
-      activityCodeFinalisationProvider.catHomeTestDataIsInvalid(ActivityCodes.FAIL_PUBLIC_SAFETY, {});
+      activityCodeFinalisationProvider.catHomeTestDataIsInvalid(
+        ActivityCodes.FAIL_PUBLIC_SAFETY,
+        {},
+        TestCategory.F,
+      );
       expect(testResultProvider.calculateTestResult).toHaveBeenCalledWith(TestCategory.F, {});
     });
   });
@@ -80,11 +100,17 @@ describe('ActivityCodeFinalisationProvider', () => {
       spyOn(testResultProvider, 'calculateTestResult').and.returnValue(of(ActivityCodes.PASS));
     });
     it('should return false when activity code is not 4/5 for Home', async () => {
-      const result = await activityCodeFinalisationProvider.catHomeTestDataIsInvalid(ActivityCodes.BAD_LIGHT, {});
+      const result = await activityCodeFinalisationProvider.catHomeTestDataIsInvalid(
+        ActivityCodes.BAD_LIGHT,
+        {},
+        TestCategory.K,
+      );
       expect(result).toBe(false);
     });
     it('should return false when activity code is not 4/5 for B', async () => {
-      const result = await activityCodeFinalisationProvider.catBTestDataIsInvalid(ActivityCodes.ACCIDENT, {});
+      const result = await activityCodeFinalisationProvider.catBTestDataIsInvalid(ActivityCodes.ACCIDENT,
+        {},
+        TestCategory.B);
       expect(result).toBe(false);
     });
     it('should return false when activity code is not 4/5 for C', async () => {
@@ -102,16 +128,26 @@ describe('ActivityCodeFinalisationProvider', () => {
     });
     it('should return false when activity code is not 4/5 for AMod1', async () => {
       const result = await activityCodeFinalisationProvider
-        .catAMod1TestDataIsInvalid(ActivityCodes.CANDIDATE_REFUSED_TO_SIGN_RESIDENCY_DECLARATION, {});
+        .catAMod1TestDataIsInvalid(
+          ActivityCodes.CANDIDATE_REFUSED_TO_SIGN_RESIDENCY_DECLARATION,
+          {},
+          TestCategory.EUA1M1,
+        );
       expect(result).toBe(false);
     });
     it('should return false when activity code is not 4/5 for AMod2', async () => {
       const result = await activityCodeFinalisationProvider
-        .catAMod2TestDataIsInvalid(ActivityCodes.ILLEGAL_ACTIVITY_FROM_CANDIDATE, {});
+        .catAMod2TestDataIsInvalid(
+          ActivityCodes.ILLEGAL_ACTIVITY_FROM_CANDIDATE,
+          {},
+          TestCategory.EUA1M2,
+        );
       expect(result).toBe(false);
     });
     it('should return false when activity code is not 4/5 for ADI2', async () => {
-      const result = await activityCodeFinalisationProvider.catADIPart2TestDataIsInvalid(ActivityCodes.BAD_LIGHT, {});
+      const result = await activityCodeFinalisationProvider.catADIPart2TestDataIsInvalid(ActivityCodes.BAD_LIGHT,
+        {},
+        TestCategory.ADI2);
       expect(result).toBe(false);
     });
   });

--- a/src/app/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
+++ b/src/app/providers/activity-code-finalisation/__tests__/activity-code-finalisation.spec.ts
@@ -93,7 +93,11 @@ describe('ActivityCodeFinalisationProvider', () => {
       expect(result).toBe(false);
     });
     it('should return false when activity code is not 4/5 for D', async () => {
-      const result = await activityCodeFinalisationProvider.catDTestDataIsInvalid(ActivityCodes.CANDIDATE_PREGNANT, {});
+      const result = await activityCodeFinalisationProvider.catDTestDataIsInvalid(
+        ActivityCodes.CANDIDATE_PREGNANT,
+        {},
+        TestCategory.D,
+      );
       expect(result).toBe(false);
     });
     it('should return false when activity code is not 4/5 for AMod1', async () => {

--- a/src/app/providers/activity-code-finalisation/activity-code-finalisation.ts
+++ b/src/app/providers/activity-code-finalisation/activity-code-finalisation.ts
@@ -101,11 +101,15 @@ export class ActivityCodeFinalisationProvider {
     return isPass;
   }
 
-  async catDTestDataIsInvalid(activityCode: ActivityCode, testData: CatDTestData): Promise<boolean> {
+  async catDTestDataIsInvalid(
+    activityCode: ActivityCode,
+    testData: CatDTestData,
+    category: TestCategory,
+  ): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.D, testData).toPromise()
+      this.testResultProvider.calculateTestResult(category, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -151,7 +155,7 @@ export class ActivityCodeFinalisationProvider {
       case TestCategory.D1:
       case TestCategory.D1E:
       case TestCategory.DE:
-      case TestCategory.D: return this.catDTestDataIsInvalid(activityCode, testData as CatDTestData);
+      case TestCategory.D: return this.catDTestDataIsInvalid(activityCode, testData as CatDTestData, category);
       case TestCategory.EUAM1:
       case TestCategory.EUA1M1:
       case TestCategory.EUA2M1:

--- a/src/app/providers/activity-code-finalisation/activity-code-finalisation.ts
+++ b/src/app/providers/activity-code-finalisation/activity-code-finalisation.ts
@@ -21,57 +21,73 @@ export class ActivityCodeFinalisationProvider {
 
   constructor(private testResultProvider: TestResultProvider) {}
 
-  async catAMod1TestDataIsInvalid(activityCode: ActivityCode, testData: CatAMod1TestData): Promise<boolean> {
+  async catAMod1TestDataIsInvalid(
+    activityCode: ActivityCode,
+    testData: CatAMod1TestData,
+    category: TestCategory,
+  ): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) {
       return false;
     }
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.EUAM1, testData).toPromise()
+      this.testResultProvider.calculateTestResult(category, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
   }
 
-  async catAMod2TestDataIsInvalid(activityCode: ActivityCode, testData: CatAMod2TestData): Promise<boolean> {
+  async catAMod2TestDataIsInvalid(
+    activityCode: ActivityCode,
+    testData: CatAMod2TestData,
+    category: TestCategory,
+  ): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.EUAM2, testData).toPromise()
+      this.testResultProvider.calculateTestResult(category, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
   }
 
   async catADIPart2TestDataIsInvalid(
-    activityCode: ActivityCode, testData: CatADI2UniqueTypes.TestData,
+    activityCode: ActivityCode,
+    testData: CatADI2UniqueTypes.TestData,
+    category: TestCategory,
   ): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.ADI2, testData).toPromise()
+      this.testResultProvider.calculateTestResult(category, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
   }
 
   async catADIPart3TestDataIsInvalid(
-    activityCode: ActivityCode, testData: CatADI3TestData,
+    activityCode: ActivityCode,
+    testData: CatADI3TestData,
+    category: TestCategory,
   ): Promise<boolean> {
     if (activityCode !== ActivityCodes.FAIL_PUBLIC_SAFETY && testData.riskManagement.score >= 8) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.ADI3, testData).toPromise()
+      this.testResultProvider.calculateTestResult(category, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
   }
 
-  async catBTestDataIsInvalid(activityCode: ActivityCode, testData: CatBUniqueTypes.TestData): Promise<boolean> {
+  async catBTestDataIsInvalid(
+    activityCode: ActivityCode,
+    testData: CatBUniqueTypes.TestData,
+    category: TestCategory,
+  ): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.B, testData).toPromise()
+      this.testResultProvider.calculateTestResult(category, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -91,11 +107,15 @@ export class ActivityCodeFinalisationProvider {
     return isPass;
   }
 
-  async catManoeuvresTestDataIsInvalid(activityCode: ActivityCode, testData: CatManoeuvreTestData): Promise<boolean> {
+  async catManoeuvresTestDataIsInvalid(
+    activityCode: ActivityCode,
+    testData: CatManoeuvreTestData,
+    category: TestCategory,
+  ): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.CM, testData).toPromise()
+      this.testResultProvider.calculateTestResult(category, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -115,11 +135,15 @@ export class ActivityCodeFinalisationProvider {
     return isPass;
   }
 
-  async catHomeTestDataIsInvalid(activityCode: ActivityCode, testData: CatHomeTestData): Promise<boolean> {
+  async catHomeTestDataIsInvalid(
+    activityCode: ActivityCode,
+    testData: CatHomeTestData,
+    category: TestCategory,
+  ): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.F, testData).toPromise()
+      this.testResultProvider.calculateTestResult(category, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -133,16 +157,18 @@ export class ActivityCodeFinalisationProvider {
   public async testDataIsInvalid(category, activityCode: ActivityCode, testData: TestDataUnion): Promise<boolean> {
     switch (category) {
       case TestCategory.ADI2: return this.catADIPart2TestDataIsInvalid(
-        activityCode, testData as CatADI2UniqueTypes.TestData,
+        activityCode, testData as CatADI2UniqueTypes.TestData, category,
       );
       case TestCategory.ADI3:
       case TestCategory.SC:
-        return this.catADIPart3TestDataIsInvalid(activityCode, testData as CatADI3TestData);
-      case TestCategory.B: return this.catBTestDataIsInvalid(activityCode, testData as CatBUniqueTypes.TestData);
+        return this.catADIPart3TestDataIsInvalid(activityCode, testData as CatADI3TestData, category);
+      case TestCategory.B:
+        return this.catBTestDataIsInvalid(activityCode, testData as CatBUniqueTypes.TestData, category);
       case TestCategory.C1:
       case TestCategory.C1E:
       case TestCategory.CE:
-      case TestCategory.C: return this.catCTestDataIsInvalid(activityCode, testData as CatCTestData, category);
+      case TestCategory.C:
+        return this.catCTestDataIsInvalid(activityCode, testData as CatCTestData, category);
       case TestCategory.C1M:
       case TestCategory.CEM:
       case TestCategory.C1EM:
@@ -151,23 +177,26 @@ export class ActivityCodeFinalisationProvider {
       case TestCategory.DEM:
       case TestCategory.D1EM:
       case TestCategory.DM:
-        return this.catManoeuvresTestDataIsInvalid(activityCode, testData as CatManoeuvreTestData);
+        return this.catManoeuvresTestDataIsInvalid(activityCode, testData as CatManoeuvreTestData, category);
       case TestCategory.D1:
       case TestCategory.D1E:
       case TestCategory.DE:
-      case TestCategory.D: return this.catDTestDataIsInvalid(activityCode, testData as CatDTestData, category);
+      case TestCategory.D:
+        return this.catDTestDataIsInvalid(activityCode, testData as CatDTestData, category);
       case TestCategory.EUAM1:
       case TestCategory.EUA1M1:
       case TestCategory.EUA2M1:
-      case TestCategory.EUAMM1: return this.catAMod1TestDataIsInvalid(activityCode, testData as CatAMod1TestData);
+      case TestCategory.EUAMM1:
+        return this.catAMod1TestDataIsInvalid(activityCode, testData as CatAMod1TestData, category);
       case TestCategory.EUAM2:
       case TestCategory.EUA1M2:
       case TestCategory.EUA2M2:
-      case TestCategory.EUAMM2: return this.catAMod2TestDataIsInvalid(activityCode, testData as CatAMod2TestData);
+      case TestCategory.EUAMM2:
+        return this.catAMod2TestDataIsInvalid(activityCode, testData as CatAMod2TestData, category);
       case TestCategory.F:
       case TestCategory.G:
       case TestCategory.H:
-      case TestCategory.K: return this.catHomeTestDataIsInvalid(activityCode, testData as CatHomeTestData);
+      case TestCategory.K: return this.catHomeTestDataIsInvalid(activityCode, testData as CatHomeTestData, category);
       default: return false;
     }
   }

--- a/src/app/providers/activity-code-finalisation/activity-code-finalisation.ts
+++ b/src/app/providers/activity-code-finalisation/activity-code-finalisation.ts
@@ -77,11 +77,15 @@ export class ActivityCodeFinalisationProvider {
     return isPass;
   }
 
-  async catCTestDataIsInvalid(activityCode: ActivityCode, testData: CatCTestData): Promise<boolean> {
+  async catCTestDataIsInvalid(
+    activityCode: ActivityCode,
+    testData: CatCTestData,
+    category: TestCategory,
+  ): Promise<boolean> {
     if (!this.activityCodeIs4or5(activityCode)) return false;
 
     const isPass = await (
-      this.testResultProvider.calculateTestResult(TestCategory.C, testData).toPromise()
+      this.testResultProvider.calculateTestResult(category, testData).toPromise()
     ) === ActivityCodes.PASS;
 
     return isPass;
@@ -134,7 +138,7 @@ export class ActivityCodeFinalisationProvider {
       case TestCategory.C1:
       case TestCategory.C1E:
       case TestCategory.CE:
-      case TestCategory.C: return this.catCTestDataIsInvalid(activityCode, testData as CatCTestData);
+      case TestCategory.C: return this.catCTestDataIsInvalid(activityCode, testData as CatCTestData, category);
       case TestCategory.C1M:
       case TestCategory.CEM:
       case TestCategory.C1EM:

--- a/src/store/tests/tests.selector.ts
+++ b/src/store/tests/tests.selector.ts
@@ -6,11 +6,12 @@ import { get, startsWith } from 'lodash';
 import {
   ActivityCodeModel,
   activityCodeModelList,
-  activityCodeModelListDelegatedExaminer,
+  activityCodeModelListDelegatedExaminer, adi3activityCodeModelList,
 } from '@shared/constants/activity-code/activity-code.constants';
 import { DateTime } from '@shared/helpers/date-time';
 import { ActivityCodes } from '@shared/models/activity-codes';
 import { end2endPracticeSlotId, testReportPracticeSlotId } from '@shared/mocks/test-slot-ids.mock';
+import { isAnyOf } from '@shared/helpers/simplifiers';
 import { TestStatus } from './test-status/test-status.model';
 import { TestsModel } from './tests.model';
 import { TestOutcome } from './tests.constants';
@@ -70,6 +71,9 @@ export const isPassed = (test: TestResultSchemasUnion): boolean => {
 export const getActivityCode = (test: TestResultCommonSchema): ActivityCodeModel => {
   if (test.delegatedTest) {
     return activityCodeModelListDelegatedExaminer.find((code) => code.activityCode === test.activityCode);
+  }
+  if (isAnyOf(test.category, [TestCategory.ADI3, TestCategory.SC])) {
+    return adi3activityCodeModelList.find((code) => code.activityCode === test.activityCode);
   }
   return activityCodeModelList.find((code) => code.activityCode === test.activityCode);
 };


### PR DESCRIPTION
## Description
fixed an issue where the test could not end with a code 5 when the user had failed on vehicle checks but had not proceeded to test report on cat c+e.

Fixed an issue where incorrect wording would appear on the activity code field on ADI3
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
