### PR TITLE
mes-dateTimeBugFix

### DIFF
--- a/src/components/common/datetime-input/date-time-input.component.scss
+++ b/src/components/common/datetime-input/date-time-input.component.scss
@@ -1,11 +1,13 @@
 .date-modal::part(content) {
   width: 400px;
   height: 350px;
+  color: var(--gds-black);
 }
 
 .time-modal::part(content) {
   width: 400px;
   height: 270px;
+  color: var(--gds-black);
 }
 
 .time-modal-content {


### PR DESCRIPTION
## Description
Fixed a bug where the text on a dateTime component would not be visible in light mode

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
