### PR TITLE
MES-8948 | light mode time & name colour fix

### DIFF
--- a/src/app/pages/candidate-details/components/candidate-detail-navigation/candidate-detail-navigation.html
+++ b/src/app/pages/candidate-details/components/candidate-detail-navigation/candidate-detail-navigation.html
@@ -3,7 +3,7 @@
       <ion-row>
         <ion-col>
           <div id="date-container">
-            <div>
+            <div class="mes-black">
               <header-component [headerNum]="2" [id]="'name'" class="word-wrapper">Name: {{name}}</header-component>
               <header-component [headerNum]="3" [id]="'dateAndTime'">Time: {{time}} {{date}}</header-component>
             </div>


### PR DESCRIPTION
## Description
Added mes-black class to candidate-navigation in order to get name & time displaying black in light mode

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
