### PR TITLE
MES-8996 | Test Debrief cards alignment

### DIFF
--- a/src/app/pages/debrief/components/dangerous-faults-debrief-card/dangerous-faults-debrief-card.html
+++ b/src/app/pages/debrief/components/dangerous-faults-debrief-card/dangerous-faults-debrief-card.html
@@ -7,7 +7,6 @@
     </ion-card-title>
   </ion-card-header>
   <ion-card-content>
-    <ion-grid>
       <ion-row *ngFor="let dangerousFault of dangerousFaults" class="mes-data ion-align-items-center">
         <ion-col size="32" class="ion-no-padding"></ion-col>
         <ion-col size="2" class="ion-align-self-start ion-no-padding">
@@ -26,6 +25,5 @@
             id="{{dangerousFaults}}-driving-text">{{'debrief.competencies.' + dangerousFault | translate | modifyCompetencyLabel:testCategory:dangerousFault}}</div>
         </ion-col>
       </ion-row>
-    </ion-grid>
   </ion-card-content>
 </ion-card>

--- a/src/app/pages/debrief/components/dangerous-faults-debrief-card/dangerous-faults-debrief-card.html
+++ b/src/app/pages/debrief/components/dangerous-faults-debrief-card/dangerous-faults-debrief-card.html
@@ -7,6 +7,7 @@
     </ion-card-title>
   </ion-card-header>
   <ion-card-content>
+    <ion-grid>
       <ion-row *ngFor="let dangerousFault of dangerousFaults" class="mes-data ion-align-items-center">
         <ion-col size="32" class="ion-no-padding"></ion-col>
         <ion-col size="2" class="ion-align-self-start ion-no-padding">
@@ -25,5 +26,6 @@
             id="{{dangerousFaults}}-driving-text">{{'debrief.competencies.' + dangerousFault | translate | modifyCompetencyLabel:testCategory:dangerousFault}}</div>
         </ion-col>
       </ion-row>
+    </ion-grid>
   </ion-card-content>
 </ion-card>

--- a/src/app/pages/debrief/components/dangerous-faults-debrief-card/dangerous-faults-debrief-card.scss
+++ b/src/app/pages/debrief/components/dangerous-faults-debrief-card/dangerous-faults-debrief-card.scss
@@ -5,4 +5,10 @@
   .down-padding {
     padding-top: 2px;
   }
+  ion-card-header {
+    padding-left: 52px;
+  }
+  ion-card-content {
+    padding-left: 83px;
+  }
 }

--- a/src/app/pages/debrief/components/driving-faults-debrief-card/driving-faults-debrief-card.scss
+++ b/src/app/pages/debrief/components/driving-faults-debrief-card/driving-faults-debrief-card.scss
@@ -5,4 +5,10 @@
   .down-padding {
     padding-top: 2px;
   }
+  ion-card-header {
+    padding-left: 52px;
+  }
+  ion-card-content {
+    padding-left: 81px;
+  }
 }

--- a/src/app/pages/debrief/components/serious-faults-debrief-card/serious-faults-debrief-card.scss
+++ b/src/app/pages/debrief/components/serious-faults-debrief-card/serious-faults-debrief-card.scss
@@ -5,4 +5,10 @@
   .down-padding {
     padding-top: 2px;
   }
+  ion-card-header {
+    padding-left: 52px;
+  }
+  ion-card-content {
+    padding-left: 81px;
+  }
 }


### PR DESCRIPTION
## Description
Added left padding to fault debrief card elements to properly align
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
![Screenshot 2023-08-24 at 10 18 40](https://github.com/dvsa/des-mobile-app/assets/45790769/7f26c361-aec3-48b0-89ac-1d8ec605bc1d)
