### PR TITLE
MES-9156 / Journal/App fixes

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ if (os) {
   console.log('Total number of CPU\'s available:', os.cpus().length);
 
   if (os.cpus().length <= 2) {
-    executors = 1;
+    executors = os.cpus().length;
   }
 }
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,7 @@ if (os) {
   console.log('Total number of CPU\'s available:', os.cpus().length);
 
   if (os.cpus().length <= 2) {
-    executors = os.cpus().length;
+    executors = 1;
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,6 +91,7 @@
         "@ionic/angular-toolkit": "^10.0.0",
         "@ionic/cli": "^7.1.1",
         "@sentry/cli": "^2.20.6",
+        "@types/deep-diff": "^1.0.5",
         "@types/hammerjs": "^2.0.41",
         "@types/jasmine": "~4.3.5",
         "@types/lodash": "^4.14.198",
@@ -4836,6 +4837,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-diff": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/deep-diff/-/deep-diff-1.0.5.tgz",
+      "integrity": "sha512-PQyNSy1YMZU1hgZA5tTYfHPpUAo9Dorn1PZho2/budQLfqLu3JIP37JAavnwYpR1S2yFZTXa3hxaE4ifGW5jaA==",
+      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "8.44.2",
@@ -23624,6 +23631,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/deep-diff": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/deep-diff/-/deep-diff-1.0.5.tgz",
+      "integrity": "sha512-PQyNSy1YMZU1hgZA5tTYfHPpUAo9Dorn1PZho2/budQLfqLu3JIP37JAavnwYpR1S2yFZTXa3hxaE4ifGW5jaA==",
+      "dev": true
     },
     "@types/eslint": {
       "version": "8.44.2",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "@ionic/angular-toolkit": "^10.0.0",
     "@ionic/cli": "^7.1.1",
     "@sentry/cli": "^2.20.6",
+    "@types/deep-diff": "^1.0.5",
     "@types/hammerjs": "^2.0.41",
     "@types/jasmine": "~4.3.5",
     "@types/lodash": "^4.14.198",

--- a/src/app/pages/back-to-office/back-to-office.page.ts
+++ b/src/app/pages/back-to-office/back-to-office.page.ts
@@ -69,8 +69,9 @@ export class BackToOfficePage extends PracticeableBasePageComponent {
     super(platform, authenticationProvider, router, store$, false);
   }
 
-  async ngOnInit(): Promise<void> {
+  ngOnInit(): void {
     super.ngOnInit();
+
     this.pageState = {
       isRekey$: this.store$.pipe(
         select(getTests),
@@ -95,8 +96,6 @@ export class BackToOfficePage extends PracticeableBasePageComponent {
       isRekey$.pipe(map((value) => this.isRekey = value)),
     );
 
-    this.singleAppModeEnabled = super.isIos() ? await this.deviceProvider.isSAMEnabled() : false;
-
     this.subscription = this.merged$.subscribe();
     this.destroyTestSubs();
   }
@@ -104,6 +103,10 @@ export class BackToOfficePage extends PracticeableBasePageComponent {
   async ionViewDidEnter(): Promise<void> {
     this.store$.dispatch(BackToOfficeViewDidEnter());
     this.store$.dispatch(ClearVehicleData());
+
+    this.singleAppModeEnabled = (super.isIos())
+      ? await this.deviceProvider.isSAMEnabled()
+      : false;
 
     if (super.isIos()) {
       await ScreenOrientation.unlock();

--- a/src/app/pages/confirm-test-details/confirm-test-details.page.html
+++ b/src/app/pages/confirm-test-details/confirm-test-details.page.html
@@ -60,8 +60,7 @@
         <data-row
           *ngIf="isPassed(pageState.testOutcomeText$ | async) && !displayForCategory(category)"
           [idPrefix]="idPrefix"
-          [label]="'Provisional licence'"
-          [label2]="'received'"
+          [label]="'Provisional licence received'"
           [value]="getProvisionalText(pageState.provisionalLicense$ | async)">
         </data-row>
         <!-- Transmission -->

--- a/src/app/pages/dashboard/dashboard.page.ts
+++ b/src/app/pages/dashboard/dashboard.page.ts
@@ -48,6 +48,7 @@ import {
   UpdateAvailablePopup,
 } from '@store/app-info/app-info.actions';
 import { DashboardViewDidEnter, PracticeTestReportCard } from './dashboard.actions';
+import { AppConfig } from '@providers/app-config/app-config.model';
 
 interface DashboardPageState {
   appVersion$: Observable<string>;
@@ -74,6 +75,7 @@ export class DashboardPage extends BasePageComponent {
   subscription: Subscription;
   private merged$: Observable<void | string>;
   private static readonly CompanyPortalURLScheme = 'companyportal://apps';
+  private appConf: AppConfig;
 
   constructor(
     protected alertController: AlertController,
@@ -157,6 +159,9 @@ export class DashboardPage extends BasePageComponent {
     this.todaysDate = this.dateTimeProvider.now();
     this.todaysDateFormatted = this.dateTimeProvider.now()
       .format('dddd Do MMMM YYYY');
+
+    this.appConf = await this.appConfigProvider.getAppConfigAsync();
+
     return true;
   }
 
@@ -168,14 +173,11 @@ export class DashboardPage extends BasePageComponent {
     }
   }
 
-  showTestReportPracticeMode = (): boolean =>
-    this.appConfigProvider.getAppConfig()?.journal.enableTestReportPracticeMode;
+  showTestReportPracticeMode = (): boolean => this.appConf?.journal.enableTestReportPracticeMode;
 
-  showEndToEndPracticeMode = (): boolean =>
-    this.appConfigProvider.getAppConfig()?.journal.enableEndToEndPracticeMode;
+  showEndToEndPracticeMode = (): boolean => this.appConf?.journal.enableEndToEndPracticeMode;
 
-  showDelegatedExaminerRekey = (): boolean =>
-    this.appConfigProvider.getAppConfig()?.role === ExaminerRole.DLG;
+  showDelegatedExaminerRekey = (): boolean => this.appConf?.role === ExaminerRole.DLG;
 
   getRoleDisplayValue = (role: string): string => ExaminerRoleDescription[role] || 'Unknown Role';
 

--- a/src/app/pages/dashboard/dashboard.page.ts
+++ b/src/app/pages/dashboard/dashboard.page.ts
@@ -48,7 +48,6 @@ import {
   UpdateAvailablePopup,
 } from '@store/app-info/app-info.actions';
 import { DashboardViewDidEnter, PracticeTestReportCard } from './dashboard.actions';
-import { AppConfig } from '@providers/app-config/app-config.model';
 
 interface DashboardPageState {
   appVersion$: Observable<string>;
@@ -75,7 +74,6 @@ export class DashboardPage extends BasePageComponent {
   subscription: Subscription;
   private merged$: Observable<void | string>;
   private static readonly CompanyPortalURLScheme = 'companyportal://apps';
-  private appConf: AppConfig;
 
   constructor(
     protected alertController: AlertController,
@@ -160,7 +158,7 @@ export class DashboardPage extends BasePageComponent {
     this.todaysDateFormatted = this.dateTimeProvider.now()
       .format('dddd Do MMMM YYYY');
 
-    this.appConf = await this.appConfigProvider.getAppConfigAsync();
+    await this.appConfigProvider.getAppConfigAsync();
 
     return true;
   }
@@ -173,11 +171,14 @@ export class DashboardPage extends BasePageComponent {
     }
   }
 
-  showTestReportPracticeMode = (): boolean => this.appConf?.journal.enableTestReportPracticeMode;
+  showTestReportPracticeMode = (): boolean =>
+    this.appConfigProvider.getAppConfig()?.journal.enableTestReportPracticeMode;
 
-  showEndToEndPracticeMode = (): boolean => this.appConf?.journal.enableEndToEndPracticeMode;
+  showEndToEndPracticeMode = (): boolean =>
+    this.appConfigProvider.getAppConfig()?.journal.enableEndToEndPracticeMode;
 
-  showDelegatedExaminerRekey = (): boolean => this.appConf?.role === ExaminerRole.DLG;
+  showDelegatedExaminerRekey = (): boolean =>
+    this.appConfigProvider.getAppConfig()?.role === ExaminerRole.DLG;
 
   getRoleDisplayValue = (role: string): string => ExaminerRoleDescription[role] || 'Unknown Role';
 

--- a/src/app/pages/journal/__tests__/journal.page.spec.ts
+++ b/src/app/pages/journal/__tests__/journal.page.spec.ts
@@ -152,17 +152,6 @@ describe('JournalPage', () => {
     });
   });
 
-  describe('logout', () => {
-    it('should dispatch an UnloadJournal action and call base page logout', () => {
-      spyOn(BasePageComponent.prototype, 'logout');
-      component.logout();
-      expect(store$.dispatch)
-        .toHaveBeenCalledWith(journalActions.UnloadJournal());
-      expect(BasePageComponent.prototype.logout)
-        .toHaveBeenCalled();
-    });
-  });
-
   describe('loadJournalManually', () => {
     it('should dispatch a LoadJournal action', async () => {
       await component.loadJournalManually();

--- a/src/app/pages/journal/__tests__/journal.page.spec.ts
+++ b/src/app/pages/journal/__tests__/journal.page.spec.ts
@@ -194,6 +194,7 @@ describe('JournalPage', () => {
           component: ErrorPage,
           componentProps: {
             errorType: ErrorTypes.JOURNAL_REFRESH,
+            displayAsModal: true,
           },
           cssClass: 'modal-fullscreen text-zoom-regular',
         });

--- a/src/app/pages/journal/components/journal-slot/journal-slot.html
+++ b/src/app/pages/journal/components/journal-slot/journal-slot.html
@@ -26,9 +26,6 @@
         <test-slot
           *ngSwitchCase="'test-slot'"
           [delegatedTest]="false"
-          [derivedActivityCode]="hasSlotBeenTested(slot.slotData, completedTests)"
-          [derivedPassCertificate]="didSlotPass(slot.slotData, completedTests)"
-          [derivedTestStatus]="derivedTestStatus(slot?.slotData, completedTests)"
           [hasSeenCandidateDetails]="slot?.hasSeenCandidateDetails"
           [hasSlotChanged]="slot?.hasSlotChanged"
           [isPortrait]="isPortrait"

--- a/src/app/pages/journal/components/journal-slot/journal-slot.ts
+++ b/src/app/pages/journal/components/journal-slot/journal-slot.ts
@@ -66,7 +66,7 @@ export class JournalSlotComponent {
   };
 
   getSlots() {
-    return this.slots.map((data) => data.slotData);
+    return (this.slots || []).map((data) => data.slotData);
   }
 
   showLocation = (

--- a/src/app/pages/journal/journal.page.ts
+++ b/src/app/pages/journal/journal.page.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { IonRefresher, ModalController, Platform } from '@ionic/angular';
 import { select, Store } from '@ngrx/store';
 import { LoadingOptions } from '@ionic/core';
-import { BehaviorSubject, merge, Observable, of, Subscription } from 'rxjs';
+import { merge, Observable, of, Subscription } from 'rxjs';
 import { map, switchMap } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { SearchResultTestSchema } from '@dvsa/mes-search-schema';
@@ -70,7 +70,6 @@ export class JournalPage extends BasePageComponent implements OnInit {
   merged$: Observable<any>;
   todaysDate: DateTime;
   platformSubscription: Subscription;
-  isPortraitMode$: BehaviorSubject<boolean> = new BehaviorSubject(false);
 
   constructor(
     public modalController: ModalController,
@@ -215,23 +214,22 @@ export class JournalPage extends BasePageComponent implements OnInit {
     return null;
   };
 
-  showError = (error: MesError): void => {
+  showError = async (error: MesError) => {
     if (error === undefined || error.message === '') return;
     // Modals are at the same level as the ion-nav so are not getting the zoom level class,
     // this needs to be passed in the create options.
 
     const zoomClass = `modal-fullscreen ${this.accessibilityService.getTextZoomClass()}`;
 
-    this.modalController.create({
+    const modal = await this.modalController.create({
       component: ErrorPage,
       componentProps: {
         errorType: ErrorTypes.JOURNAL_REFRESH,
       },
       cssClass: zoomClass,
-    })
-      .then((modal) => {
-        modal.present();
-      });
+    });
+
+    await modal.present();
   };
 
   public pullRefreshJournal = async (refresher: IonRefresher) => {
@@ -242,11 +240,6 @@ export class JournalPage extends BasePageComponent implements OnInit {
   public refreshJournal = async () => {
     await this.loadJournalManually();
   };
-
-  async logout() {
-    this.store$.dispatch(journalActions.UnloadJournal());
-    await super.logout();
-  }
 
   onPreviousDayClick(): void {
     this.store$.dispatch(journalActions.SelectPreviousDay());

--- a/src/app/pages/journal/journal.page.ts
+++ b/src/app/pages/journal/journal.page.ts
@@ -3,7 +3,7 @@ import { IonRefresher, ModalController, Platform } from '@ionic/angular';
 import { select, Store } from '@ngrx/store';
 import { LoadingOptions } from '@ionic/core';
 import { merge, Observable, of, Subscription } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, switchMap, take } from 'rxjs/operators';
 import { Router } from '@angular/router';
 import { SearchResultTestSchema } from '@dvsa/mes-search-schema';
 import { ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
@@ -104,6 +104,7 @@ export class JournalPage extends BasePageComponent implements OnInit {
       error$: this.store$.pipe(
         select(getJournalState),
         map(getError),
+        take(1),
       ),
       isLoading$: this.store$.pipe(
         select(getJournalState),
@@ -139,7 +140,7 @@ export class JournalPage extends BasePageComponent implements OnInit {
     } = this.pageState;
 
     this.merged$ = merge(
-      error$.pipe(map(this.showError)),
+      error$.pipe(switchMap(this.showError)),
       isLoading$.pipe(map(this.handleLoadingUI)),
     );
   }
@@ -225,6 +226,7 @@ export class JournalPage extends BasePageComponent implements OnInit {
       component: ErrorPage,
       componentProps: {
         errorType: ErrorTypes.JOURNAL_REFRESH,
+        displayAsModal: true,
       },
       cssClass: zoomClass,
     });

--- a/src/app/pages/login/login.page.ts
+++ b/src/app/pages/login/login.page.ts
@@ -39,11 +39,14 @@ export class LoginPage extends LogoutBasePageComponent implements OnInit {
   hasDeviceTypeError = false;
   deviceTypeError: DeviceError;
   queryParamSub: Subscription;
-  private static loadingOptions = {
-    id: 'app_init_spinner',
-    spinner: 'circles',
-    message: 'App initialising...',
-  } as LoadingOptions;
+
+  get loadingOptions(): LoadingOptions {
+    return {
+      id: 'app_init_spinner',
+      spinner: 'circles',
+      message: 'App initialising...',
+    };
+  }
 
   constructor(
     platform: Platform,
@@ -257,7 +260,7 @@ export class LoginPage extends LogoutBasePageComponent implements OnInit {
   }
 
   async handleLoadingUI(isLoading: boolean): Promise<void> {
-    await this.loadingProvider.handleUILoading(isLoading, LoginPage.loadingOptions);
+    await this.loadingProvider.handleUILoading(isLoading, this.loadingOptions);
   }
 
 }

--- a/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.page.spec.ts
+++ b/src/app/pages/non-pass-finalisation/__tests__/non-pass-finalisation.page.spec.ts
@@ -1,9 +1,5 @@
-import {
-  ComponentFixture, fakeAsync, TestBed, tick, waitForAsync,
-} from '@angular/core/testing';
-import {
-  IonicModule, ModalController, NavController, Platform,
-} from '@ionic/angular';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { IonicModule, ModalController, NavController, Platform } from '@ionic/angular';
 import { NavControllerMock, PlatformMock } from '@mocks/index.mock';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ActivatedRoute, Data, Router } from '@angular/router';
@@ -22,9 +18,7 @@ import * as testActions from '@store/tests/tests.actions';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { D255Component } from '@components/test-finalisation/d255/d255';
 import { LanguagePreferencesComponent } from '@components/test-finalisation/language-preference/language-preference';
-import {
-  D255No, D255Yes, DebriefUnWitnessed, DebriefWitnessed,
-} from '@store/tests/test-summary/test-summary.actions';
+import { D255No, D255Yes, DebriefUnWitnessed, DebriefWitnessed } from '@store/tests/test-summary/test-summary.actions';
 import { DebriefWitnessedComponent } from '@components/test-finalisation/debrief-witnessed/debrief-witnessed';
 import { FinalisationHeaderComponent } from '@components/test-finalisation/finalisation-header/finalisation-header';
 import {
@@ -89,7 +83,10 @@ describe('NonPassFinalisationPage', () => {
           version: '1',
           rekey: false,
           activityCode: '1',
-          passCompletion: { passCertificateNumber: 'test', code78: true },
+          passCompletion: {
+            passCertificateNumber: 'test',
+            code78: true,
+          },
           category: TestCategory.SC,
           changeMarker: null,
           examinerBooked: null,
@@ -143,15 +140,42 @@ describe('NonPassFinalisationPage', () => {
         AppModule,
       ],
       providers: [
-        { provide: Router, useClass: RouterMock },
-        { provide: NavController, useClass: NavControllerMock },
-        { provide: Platform, useClass: PlatformMock },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: ActivityCodeFinalisationProvider, useClass: ActivityCodeFinalisationMock },
-        { provide: OutcomeBehaviourMapProvider, useClass: OutcomeBehaviourMapProviderMock },
-        { provide: ActivatedRoute, useValue: activatedRouteMock },
-        { provide: ModalController, useClass: ModalControllerMock },
-        { provide: TestDataByCategoryProvider, useClass: TestDataByCategoryProviderMock },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: ActivityCodeFinalisationProvider,
+          useClass: ActivityCodeFinalisationMock,
+        },
+        {
+          provide: OutcomeBehaviourMapProvider,
+          useClass: OutcomeBehaviourMapProviderMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: activatedRouteMock,
+        },
+        {
+          provide: ModalController,
+          useClass: ModalControllerMock,
+        },
+        {
+          provide: TestDataByCategoryProvider,
+          useClass: TestDataByCategoryProviderMock,
+        },
         provideMockStore({ initialState }),
       ],
     });
@@ -169,7 +193,9 @@ describe('NonPassFinalisationPage', () => {
 
     describe('ngOnInit', () => {
       it('should resolve state variables', () => {
-        spyOn(outcomeBehaviourProvider, 'isVisible').and.returnValue(true);
+        spyOn(outcomeBehaviourProvider, 'isVisible')
+          .and
+          .returnValue(true);
 
         component.ngOnInit();
         component.pageState.displayDebriefWitnessed$
@@ -230,49 +256,64 @@ describe('NonPassFinalisationPage', () => {
     describe('ionViewDidEnter', () => {
       it('should dispatch a view did enter action', () => {
         component.ionViewDidEnter();
-        expect(store$.dispatch).toHaveBeenCalledWith(NonPassFinalisationViewDidEnter());
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(NonPassFinalisationViewDidEnter());
+        expect(store$.dispatch)
+          .toHaveBeenCalledTimes(1);
       });
       it('should dispatch D255No is test category is ADI2', () => {
         component.testCategory = TestCategory.ADI2;
         component.ionViewDidEnter();
-        expect(store$.dispatch).toHaveBeenCalledWith(D255No());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(D255No());
       });
     });
     describe('d255Changed', () => {
       it('should dispatch the correct action if the inputted value is true', () => {
         component.d255Changed(true);
-        expect(store$.dispatch).toHaveBeenCalledWith(D255Yes());
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(D255Yes());
+        expect(store$.dispatch)
+          .toHaveBeenCalledTimes(1);
       });
       it('should dispatch the correct action if the inputted value is false', () => {
         component.d255Changed(false);
-        expect(store$.dispatch).toHaveBeenCalledWith(D255No());
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(D255No());
+        expect(store$.dispatch)
+          .toHaveBeenCalledTimes(1);
       });
     });
     describe('debriefWitnessedChanged', () => {
       it('should dispatch the correct action if the inputted value is true', () => {
         component.debriefWitnessedChanged(true);
-        expect(store$.dispatch).toHaveBeenCalledWith(DebriefWitnessed());
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(DebriefWitnessed());
+        expect(store$.dispatch)
+          .toHaveBeenCalledTimes(1);
       });
       it('should dispatch the correct action if the inputted value is false', () => {
         component.debriefWitnessedChanged(false);
-        expect(store$.dispatch).toHaveBeenCalledWith(DebriefUnWitnessed());
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(DebriefUnWitnessed());
+        expect(store$.dispatch)
+          .toHaveBeenCalledTimes(1);
       });
     });
     describe('isWelshChanged', () => {
       it('should dispatch the correct action if the isWelsh flag is true', () => {
         component.isWelshChanged(true);
-        expect(store$.dispatch).toHaveBeenCalledWith(CandidateChoseToProceedWithTestInWelsh('Cymraeg'));
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(CandidateChoseToProceedWithTestInWelsh('Cymraeg'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledTimes(1);
       });
       it('should dispatch the correct action if the isWelsh flag is false', () => {
         component.isWelshChanged(false);
-        expect(store$.dispatch).toHaveBeenCalledWith(CandidateChoseToProceedWithTestInEnglish('English'));
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(CandidateChoseToProceedWithTestInEnglish('English'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledTimes(1);
       });
     });
     describe('onCancel', () => {
@@ -280,7 +321,8 @@ describe('NonPassFinalisationPage', () => {
         await component.openTestDataValidationModal();
         spyOn(component.invalidTestDataModal, 'dismiss');
         await component.onCancel();
-        expect(component.invalidTestDataModal.dismiss).toHaveBeenCalled();
+        expect(component.invalidTestDataModal.dismiss)
+          .toHaveBeenCalled();
       });
     });
     describe('onReturnToTestReport', () => {
@@ -288,40 +330,49 @@ describe('NonPassFinalisationPage', () => {
         await component.openTestDataValidationModal();
         spyOn(component.invalidTestDataModal, 'dismiss');
         await component.onReturnToTestReport();
-        expect(component.invalidTestDataModal.dismiss).toHaveBeenCalled();
+        expect(component.invalidTestDataModal.dismiss)
+          .toHaveBeenCalled();
       });
       it('should call navigateToPage with TEST_REPORT_DASHBOARD_PAGE if'
-          + ' test category is ADI3', async () => {
+        + ' test category is ADI3', async () => {
         spyOn(component.routeByCat, 'navigateToPage');
         await component.openTestDataValidationModal();
 
         component.testCategory = TestCategory.ADI3;
 
         await component.onReturnToTestReport();
-        expect(component.routeByCat.navigateToPage).toHaveBeenCalledWith(TestFlowPageNames.TEST_REPORT_DASHBOARD_PAGE);
+        expect(component.routeByCat.navigateToPage)
+          .toHaveBeenCalledWith(TestFlowPageNames.TEST_REPORT_DASHBOARD_PAGE);
       });
       it('should call navigateToPage with TEST_REPORT_PAGE and testCategory if'
-          + ' test category is not ADI3', async () => {
+        + ' test category is not ADI3', async () => {
         spyOn(component.routeByCat, 'navigateToPage');
         await component.openTestDataValidationModal();
 
         component.testCategory = TestCategory.B;
 
         await component.onReturnToTestReport();
-        expect(component.routeByCat.navigateToPage).toHaveBeenCalledWith(
-          TestFlowPageNames.TEST_REPORT_PAGE, TestCategory.B,
-        );
+        expect(component.routeByCat.navigateToPage)
+          .toHaveBeenCalledWith(
+            TestFlowPageNames.TEST_REPORT_PAGE, TestCategory.B,
+          );
       });
     });
     describe('continue', () => {
       it(`should create the TestFinalisationInvalidTestDataModal
       when activityCode is 5 and no S/D faults`, async () => {
         store$.dispatch(testActions.StartTest(123, TestCategory.B));
-        spyOn(component, 'openTestDataValidationModal').and.callThrough();
-        spyOn(component.modalController, 'create').and.callThrough();
-        spyOn(component.activityCodeFinalisationProvider, 'testDataIsInvalid').and.returnValue(Promise.resolve(true));
+        spyOn(component, 'openTestDataValidationModal')
+          .and
+          .callThrough();
+        spyOn(component.modalController, 'create')
+          .and
+          .callThrough();
+        spyOn(component.activityCodeFinalisationProvider, 'testDataIsInvalid')
+          .and
+          .returnValue(Promise.resolve(true));
 
-        component.slotId = '123';
+        // component.slotId = '123';
         component.activityCode = {
           activityCode: ActivityCodes.FAIL_CANDIDATE_STOPS_TEST,
           description: ActivityCodeDescription.FAIL_CANDIDATE_STOPS_TEST,
@@ -335,32 +386,47 @@ describe('NonPassFinalisationPage', () => {
         await component.continue();
 
         // Assert
-        expect(component.openTestDataValidationModal).toHaveBeenCalled();
-        expect(component.modalController.create).toHaveBeenCalled();
+        expect(component.openTestDataValidationModal)
+          .toHaveBeenCalled();
+        expect(component.modalController.create)
+          .toHaveBeenCalled();
       });
       it(`should dispatch NonPassFinalisationReportActivityCode with activity code and call navigateToPage
       with CONFIRM_TEST_DETAILS_PAGE if testDataIsInvalid is false`, async () => {
-        component.activityCode = { activityCode: '2', description: ActivityCodeDescription.FAIL };
+        component.activityCode = {
+          activityCode: '2',
+          description: ActivityCodeDescription.FAIL,
+        };
         store$.dispatch(testActions.StartTest(123, TestCategory.B));
 
         spyOn(component.routeByCat, 'navigateToPage');
-        spyOn(component, 'openTestDataValidationModal').and.callThrough();
-        spyOn(component.modalController, 'create').and.callThrough();
-        spyOn(component.activityCodeFinalisationProvider, 'testDataIsInvalid').and.returnValue(Promise.resolve(false));
+        spyOn(component, 'openTestDataValidationModal')
+          .and
+          .callThrough();
+        spyOn(component.modalController, 'create')
+          .and
+          .callThrough();
+        spyOn(component.activityCodeFinalisationProvider, 'testDataIsInvalid')
+          .and
+          .returnValue(Promise.resolve(false));
 
         // Act
         await component.continue();
 
         // Assert
-        expect(store$.dispatch).toHaveBeenCalledWith(NonPassFinalisationReportActivityCode(ActivityCodes.FAIL));
-        expect(component.routeByCat.navigateToPage).toHaveBeenCalledWith(TestFlowPageNames.CONFIRM_TEST_DETAILS_PAGE);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(NonPassFinalisationReportActivityCode(ActivityCodes.FAIL));
+        expect(component.routeByCat.navigateToPage)
+          .toHaveBeenCalledWith(TestFlowPageNames.CONFIRM_TEST_DETAILS_PAGE);
       });
 
       it(`should create the TestFinalisationInvalidTestDataModal
       when activityCode is 4 and no S/D faults`, async () => {
         // Arrange
         store$.dispatch(testActions.StartTest(123, TestCategory.B));
-        spyOn(component, 'openTestDataValidationModal').and.callThrough();
+        spyOn(component, 'openTestDataValidationModal')
+          .and
+          .callThrough();
         spyOn(component.modalController, 'create')
           .and
           .callThrough();
@@ -368,7 +434,7 @@ describe('NonPassFinalisationPage', () => {
           .and
           .returnValue(Promise.resolve(true));
 
-        component.slotId = '123';
+        // component.slotId = '123';
         component.activityCode = {
           activityCode: ActivityCodes.FAIL_PUBLIC_SAFETY,
           description: ActivityCodeDescription.FAIL_PUBLIC_SAFETY,
@@ -382,8 +448,10 @@ describe('NonPassFinalisationPage', () => {
         await component.continue();
 
         // Assert
-        expect(component.openTestDataValidationModal).toHaveBeenCalled();
-        expect(component.modalController.create).toHaveBeenCalled();
+        expect(component.openTestDataValidationModal)
+          .toHaveBeenCalled();
+        expect(component.modalController.create)
+          .toHaveBeenCalled();
       });
 
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
@@ -416,40 +484,50 @@ describe('NonPassFinalisationPage', () => {
     describe('navigateToDebrief', () => {
       it('should call the back method from Location to navigate back to Debrief', async () => {
         await component.navigateToDebrief();
-        expect(router.navigate).toHaveBeenCalledWith([TestFlowPageNames.DEBRIEF_PAGE]);
+        expect(router.navigate)
+          .toHaveBeenCalledWith([TestFlowPageNames.DEBRIEF_PAGE]);
       });
     });
     describe('isADI3', () => {
       it('should return true if TestCategory is ADI3', () => {
         component.testCategory = TestCategory.ADI3;
-        expect(component.isADI3()).toEqual(true);
+        expect(component.isADI3())
+          .toEqual(true);
       });
       it('should return false if TestCategory is not ADI3', () => {
         component.testCategory = TestCategory.B;
-        expect(component.isADI3()).toEqual(false);
+        expect(component.isADI3())
+          .toEqual(false);
       });
     });
     describe('showLanguage', () => {
       it('should return false if TestCategory is ADI3', () => {
         component.testCategory = TestCategory.ADI3;
-        expect(component.showLanguage()).toEqual(false);
+        expect(component.showLanguage())
+          .toEqual(false);
       });
       it('should return true if TestCategory is not ADI3', () => {
         component.testCategory = TestCategory.B;
-        expect(component.showLanguage()).toEqual(true);
+        expect(component.showLanguage())
+          .toEqual(true);
       });
     });
     describe('furtherDevelopmentChanged', () => {
       it('should dispatch SeekFurtherDevelopmentChanged using the parameter given', () => {
         component.furtherDevelopmentChanged(true);
-        expect(store$.dispatch).toHaveBeenCalledWith(SeekFurtherDevelopmentChanged(true));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(SeekFurtherDevelopmentChanged(true));
       });
     });
     describe('activityCodeChanged', () => {
       it('should set activityCodee to the parameter given and dispatch SetActivityCode'
-          + ' using the activityCode provided', () => {
-        component.activityCodeChanged({ activityCode: '1', description: ActivityCodeDescription.PASS });
-        expect(store$.dispatch).toHaveBeenCalledWith(SetActivityCode('1'));
+        + ' using the activityCode provided', () => {
+        component.activityCodeChanged({
+          activityCode: '1',
+          description: ActivityCodeDescription.PASS,
+        });
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(SetActivityCode('1'));
       });
     });
     describe('ionViewDidLeave', () => {
@@ -457,13 +535,15 @@ describe('NonPassFinalisationPage', () => {
         component.subscription = new Subscription();
         spyOn(component.subscription, 'unsubscribe');
         component.ionViewDidLeave();
-        expect(component.subscription.unsubscribe).toHaveBeenCalled();
+        expect(component.subscription.unsubscribe)
+          .toHaveBeenCalled();
       });
     });
     describe('adviceReasonChanged', () => {
       it('should dispatch ReasonForNoAdviceGivenChanged using the parameter given', () => {
         component.adviceReasonChanged('test');
-        expect(store$.dispatch).toHaveBeenCalledWith(ReasonForNoAdviceGivenChanged('test'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(ReasonForNoAdviceGivenChanged('test'));
       });
     });
     describe('didTestComplete', () => {
@@ -472,17 +552,26 @@ describe('NonPassFinalisationPage', () => {
         ActivityCodes.FAIL_PUBLIC_SAFETY,
         ActivityCodes.FAIL_CANDIDATE_STOPS_TEST].forEach((value) => {
         it(`should return true if activity code is ${value}`, () => {
-          component.activityCode = { activityCode: value, description: null };
-          expect(component.didTestComplete()).toEqual(true);
+          component.activityCode = {
+            activityCode: value,
+            description: null,
+          };
+          expect(component.didTestComplete())
+            .toEqual(true);
         });
       });
       it('should return false if activityCode is not on the accepted list', () => {
-        component.activityCode = { activityCode: ActivityCodes.PASS, description: null };
-        expect(component.didTestComplete()).toEqual(false);
+        component.activityCode = {
+          activityCode: ActivityCodes.PASS,
+          description: null,
+        };
+        expect(component.didTestComplete())
+          .toEqual(false);
       });
       it('should return false if there is no activity code', () => {
         component.activityCode = null;
-        expect(component.didTestComplete()).toEqual(false);
+        expect(component.didTestComplete())
+          .toEqual(false);
       });
     });
     describe('testDataValidationMsg', () => {
@@ -492,40 +581,46 @@ describe('NonPassFinalisationPage', () => {
       ].forEach((value) => {
         it(`should return Code 4 message if Test category is ${value}`, () => {
           component.testCategory = value;
-          expect(component['testDataValidationMsg']).toEqual(
-            'Code 4 cannot be selected because the PDI has a Risk Management score of more than 7',
-          );
+          expect(component['testDataValidationMsg'])
+            .toEqual(
+              'Code 4 cannot be selected because the PDI has a Risk Management score of more than 7',
+            );
         });
       });
       it('should return level of faults message if Test category is not on the case list', () => {
         component.testCategory = TestCategory.C;
-        expect(component['testDataValidationMsg']).toEqual(
-          'The level of faults on this practical test does not meet the requirement for code 4 or 5.',
-        );
+        expect(component['testDataValidationMsg'])
+          .toEqual(
+            'The level of faults on this practical test does not meet the requirement for code 4 or 5.',
+          );
       });
     });
     describe('testStartTimeChanged', () => {
       it('should dispatch endTime to store', () => {
         spyOn(store$, 'dispatch');
         component.testStartTimeChanged('test');
-        expect(store$.dispatch).toHaveBeenCalledWith(StartTimeChanged('test'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(StartTimeChanged('test'));
       });
     });
     describe('testEndTimeChanged', () => {
       it('should dispatch endTime to store', () => {
         spyOn(store$, 'dispatch');
         component.testEndTimeChanged('test');
-        expect(store$.dispatch).toHaveBeenCalledWith(EndTimeChanged('test'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(EndTimeChanged('test'));
       });
     });
     describe('showD255', () => {
       it('Hide D255 when category C3a', async () => {
         component.testCategory = TestCategory.C;
-        expect(component.showD255()).toEqual(true);
+        expect(component.showD255())
+          .toEqual(true);
       });
       it('Show D255 when is not category C3a', async () => {
         component.testCategory = TestCategory.CM;
-        expect(component.showD255()).toEqual(false);
+        expect(component.showD255())
+          .toEqual(false);
       });
     });
   });

--- a/src/app/pages/non-pass-finalisation/non-pass-finalisation.page.ts
+++ b/src/app/pages/non-pass-finalisation/non-pass-finalisation.page.ts
@@ -89,7 +89,6 @@ interface NonPassFinalisationPageState {
   d255$: Observable<boolean>;
   isWelshTest$: Observable<boolean>;
   testData$: Observable<CatBUniqueTypes.TestData>;
-  slotId$: Observable<string>;
   eyesightTestFailed$: Observable<boolean>;
   testCategory$: Observable<CategoryCode>;
   showADIWarning$: Observable<boolean>;
@@ -116,7 +115,6 @@ export class NonPassFinalisationPage extends PracticeableBasePageComponent imple
   pageState: NonPassFinalisationPageState;
   form: UntypedFormGroup;
   activityCodeOptions: ActivityCodeModel[];
-  slotId: string;
   testData: CatBUniqueTypes.TestData;
   activityCode: ActivityCodeModel;
   subscription: Subscription;
@@ -156,10 +154,6 @@ export class NonPassFinalisationPage extends PracticeableBasePageComponent imple
     const category$ = currentTest$.pipe(select(getTestCategory));
 
     this.pageState = {
-      slotId$: this.store$.pipe(
-        select(getTests),
-        map((tests) => tests.currentTest.slotId),
-      ),
       candidateName$: currentTest$.pipe(
         select(getJournalData),
         select(getCandidate),
@@ -313,7 +307,6 @@ export class NonPassFinalisationPage extends PracticeableBasePageComponent imple
 
     const {
       testData$,
-      slotId$,
       activityCode$,
       testCategory$,
       testStartTime$,
@@ -321,7 +314,6 @@ export class NonPassFinalisationPage extends PracticeableBasePageComponent imple
     } = this.pageState;
 
     this.subscription = merge(
-      slotId$.pipe(map((slotId) => this.slotId = slotId)),
       testData$.pipe(map((testData) => this.testData = testData)),
       activityCode$.pipe(map((activityCode) => this.activityCode = activityCode)),
       testCategory$.pipe(map((result) => this.testCategory = result)),

--- a/src/app/pages/post-debrief-holding/post-debrief-holding.page.ts
+++ b/src/app/pages/post-debrief-holding/post-debrief-holding.page.ts
@@ -25,10 +25,6 @@ export class PostDebriefHoldingPage extends PracticeableBasePageComponent implem
     super(platform, authenticationProvider, router, store$, false);
   }
 
-  ngOnInit(): void {
-    super.ngOnInit();
-  }
-
   async continueButton(): Promise<void> {
     await this.routeByCat.navigateToPage(TestFlowPageNames.NON_PASS_FINALISATION_PAGE);
   }

--- a/src/app/pages/waiting-room-to-car/waiting-room-to-car.effects.ts
+++ b/src/app/pages/waiting-room-to-car/waiting-room-to-car.effects.ts
@@ -2,9 +2,7 @@ import { Platform } from '@ionic/angular';
 import { Injectable } from '@angular/core';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { select, Store } from '@ngrx/store';
-import {
-  catchError, concatMap, filter, map, switchMap, withLatestFrom,
-} from 'rxjs/operators';
+import { catchError, concatMap, filter, map, switchMap, withLatestFrom } from 'rxjs/operators';
 import { of } from 'rxjs';
 
 import { StoreModel } from '@shared/models/store.model';
@@ -15,9 +13,7 @@ import { getTests } from '@store/tests/tests.reducer';
 import { getCurrentTest, isPracticeMode } from '@store/tests/tests.selector';
 import { SaveLog } from '@store/logs/logs.actions';
 import { LogType } from '@shared/models/log.model';
-import {
-  GetMotStatus, GetMotStatusFailure,
-} from '@pages/waiting-room-to-car/waiting-room-to-car.actions';
+import { GetMotStatus, GetMotStatusFailure } from '@pages/waiting-room-to-car/waiting-room-to-car.actions';
 import { MotStatusChanged } from '@store/tests/vehicle-details/vehicle-details.actions';
 import { getVehicleDetails } from '@store/tests/vehicle-details/vehicle-details.reducer';
 import { getRegistrationNumber } from '@store/tests/vehicle-details/vehicle-details.selector';
@@ -59,18 +55,23 @@ export class WaitingRoomToCarEffects {
     // above filter means we will not call through to candidate service when any of the above conditions fail.
     filter(([, , isPracticeTest]) => (
       this.platform.is('cordova')
-            && !isPracticeTest
-            && this.networkStateProvider.getNetworkState() === ConnectionStatus.ONLINE
+      && !isPracticeTest
+      && this.networkStateProvider.getNetworkState() === ConnectionStatus.ONLINE
     )),
     // once we are happy user is online and not in a practice test, then we sanitise the input by removing whitespace
-    map(([, regNumber]) => regNumber?.replace(/\s/g, '').toUpperCase()),
+    map(([, regNumber]) => regNumber?.replace(/\s/g, '')
+      .toUpperCase()),
     // filter any requests that are nulls or empty strings from hitting service
     filter((regNumber) => !!regNumber),
     switchMap((regNumber) => this.vehicleDetailsApiProvider.getVehicleByIdentifier(regNumber)),
     map((vehicleDetails) => MotStatusChanged(vehicleDetails?.status || MotStatus.NO_DETAILS)),
     catchError((err) => {
       this.store$.dispatch(SaveLog({
-        payload: this.logHelper.createLog(LogType.ERROR, 'Error retrieving MOT status', err.error),
+        payload: this.logHelper.createLog(
+          LogType.ERROR,
+          'Error retrieving MOT status',
+          (err instanceof Error) ? err.message : err.error,
+        ),
       }));
       return of(GetMotStatusFailure());
     }),

--- a/src/app/providers/app-config/__mocks__/app-config.mock.ts
+++ b/src/app/providers/app-config/__mocks__/app-config.mock.ts
@@ -3,6 +3,64 @@ import { localEnvironmentMock } from './environment.mock';
 import { AppConfig } from '../app-config.model';
 
 export class AppConfigProviderMock {
+  private appConfig = {
+    liveAppVersion: localEnvironmentMock.liveAppVersion,
+    configUrl: localEnvironmentMock.configUrl,
+    googleAnalyticsId: localEnvironmentMock.googleAnalyticsId,
+    daysToCacheLogs: localEnvironmentMock.daysToCacheLogs,
+    logoutClearsTestPersistence: localEnvironmentMock.logoutClearsTestPersistence,
+    logsPostApiKey: localEnvironmentMock.logsPostApiKey,
+    taxMotApiKey: localEnvironmentMock.taxMotApiKey,
+    logsApiUrl: localEnvironmentMock.logsApiUrl,
+    logsAutoSendInterval: localEnvironmentMock.logsAutoSendInterval,
+    authentication: {
+      clientId: localEnvironmentMock.authentication.clientId,
+      context: localEnvironmentMock.authentication.context,
+      redirectUrl: localEnvironmentMock.authentication.redirectUrl,
+      resourceUrl: localEnvironmentMock.authentication.resourceUrl,
+      logoutUrl: localEnvironmentMock.authentication.logoutUrl,
+      employeeIdKey: localEnvironmentMock.authentication.employeeIdKey,
+      employeeNameKey: localEnvironmentMock.employeeNameKey,
+    },
+    approvedDeviceIdentifiers: localEnvironmentMock.approvedDeviceIdentifiers,
+    timeTravelDate: localEnvironmentMock.timeTravelDate,
+    role: localEnvironmentMock.role,
+    journal: {
+      journalUrl: localEnvironmentMock.journal.journalUrl,
+      searchBookingUrl: localEnvironmentMock.journal.searchBookingUrl,
+      delegatedExaminerSearchBookingUrl: localEnvironmentMock.journal.delegatedExaminerSearchBookingUrl,
+      teamJournalUrl: localEnvironmentMock.journal.teamJournalUrl,
+      autoRefreshInterval: localEnvironmentMock.journal.autoRefreshInterval,
+      numberOfDaysToView: localEnvironmentMock.journal.numberOfDaysToView,
+      daysToCacheJournalData: localEnvironmentMock.journal.daysToCacheJournalData,
+      allowTests: localEnvironmentMock.journal.allowTests,
+      allowedTestCategories: localEnvironmentMock.journal.allowedTestCategories,
+      enableTestReportPracticeMode: localEnvironmentMock.journal.enableTestReportPracticeMode,
+      enableEndToEndPracticeMode: localEnvironmentMock.journal.enableEndToEndPracticeMode,
+      enablePracticeModeAnalytics: localEnvironmentMock.journal.enablePracticeModeAnalytics,
+      enableLogoutButton: localEnvironmentMock.journal.enableLogoutButton,
+      testPermissionPeriods: localEnvironmentMock.journal.testPermissionPeriods,
+    },
+    tests: {
+      testSubmissionUrl: localEnvironmentMock.tests.testSubmissionUrl,
+      autoSendInterval: localEnvironmentMock.tests.autoSendInterval,
+    },
+    user: {
+      findUserUrl: localEnvironmentMock.user.findUserUrl,
+    },
+    driver: {
+      standardUrl: localEnvironmentMock.driver.standardUrl,
+      signatureUrl: localEnvironmentMock.driver.signatureUrl,
+      photographUrl: localEnvironmentMock.driver.photographUrl,
+    },
+    vehicle: {
+      taxMotUrl: localEnvironmentMock.vehicle.taxMotUrl,
+    },
+    refData: {
+      testCentreUrl: localEnvironmentMock.refData.testCentreUrl,
+    },
+    requestTimeout: localEnvironmentMock.requestTimeout,
+  };
 
   environmentFile: EnvironmentFile = localEnvironmentMock;
 
@@ -18,65 +76,12 @@ export class AppConfigProviderMock {
     .and
     .returnValue(Promise.resolve());
 
+  public getAppConfigAsync(): Promise<AppConfig> {
+    return Promise.resolve(this.appConfig);
+  }
+
   public getAppConfig(): AppConfig {
-    return {
-      liveAppVersion: localEnvironmentMock.liveAppVersion,
-      configUrl: localEnvironmentMock.configUrl,
-      googleAnalyticsId: localEnvironmentMock.googleAnalyticsId,
-      daysToCacheLogs: localEnvironmentMock.daysToCacheLogs,
-      logoutClearsTestPersistence: localEnvironmentMock.logoutClearsTestPersistence,
-      logsPostApiKey: localEnvironmentMock.logsPostApiKey,
-      taxMotApiKey: localEnvironmentMock.taxMotApiKey,
-      logsApiUrl: localEnvironmentMock.logsApiUrl,
-      logsAutoSendInterval: localEnvironmentMock.logsAutoSendInterval,
-      authentication: {
-        clientId: localEnvironmentMock.authentication.clientId,
-        context: localEnvironmentMock.authentication.context,
-        redirectUrl: localEnvironmentMock.authentication.redirectUrl,
-        resourceUrl: localEnvironmentMock.authentication.resourceUrl,
-        logoutUrl: localEnvironmentMock.authentication.logoutUrl,
-        employeeIdKey: localEnvironmentMock.authentication.employeeIdKey,
-        employeeNameKey: localEnvironmentMock.employeeNameKey,
-      },
-      approvedDeviceIdentifiers: localEnvironmentMock.approvedDeviceIdentifiers,
-      timeTravelDate: localEnvironmentMock.timeTravelDate,
-      role: localEnvironmentMock.role,
-      journal: {
-        journalUrl: localEnvironmentMock.journal.journalUrl,
-        searchBookingUrl: localEnvironmentMock.journal.searchBookingUrl,
-        delegatedExaminerSearchBookingUrl: localEnvironmentMock.journal.delegatedExaminerSearchBookingUrl,
-        teamJournalUrl: localEnvironmentMock.journal.teamJournalUrl,
-        autoRefreshInterval: localEnvironmentMock.journal.autoRefreshInterval,
-        numberOfDaysToView: localEnvironmentMock.journal.numberOfDaysToView,
-        daysToCacheJournalData: localEnvironmentMock.journal.daysToCacheJournalData,
-        allowTests: localEnvironmentMock.journal.allowTests,
-        allowedTestCategories: localEnvironmentMock.journal.allowedTestCategories,
-        enableTestReportPracticeMode: localEnvironmentMock.journal.enableTestReportPracticeMode,
-        enableEndToEndPracticeMode: localEnvironmentMock.journal.enableEndToEndPracticeMode,
-        enablePracticeModeAnalytics: localEnvironmentMock.journal.enablePracticeModeAnalytics,
-        enableLogoutButton: localEnvironmentMock.journal.enableLogoutButton,
-        testPermissionPeriods: localEnvironmentMock.journal.testPermissionPeriods,
-      },
-      tests: {
-        testSubmissionUrl: localEnvironmentMock.tests.testSubmissionUrl,
-        autoSendInterval: localEnvironmentMock.tests.autoSendInterval,
-      },
-      user: {
-        findUserUrl: localEnvironmentMock.user.findUserUrl,
-      },
-      driver: {
-        standardUrl: localEnvironmentMock.driver.standardUrl,
-        signatureUrl: localEnvironmentMock.driver.signatureUrl,
-        photographUrl: localEnvironmentMock.driver.photographUrl,
-      },
-      vehicle: {
-        taxMotUrl: localEnvironmentMock.vehicle.taxMotUrl,
-      },
-      refData: {
-        testCentreUrl: localEnvironmentMock.refData.testCentreUrl,
-      },
-      requestTimeout: localEnvironmentMock.requestTimeout,
-    };
+    return this.appConfig;
   }
 
 }

--- a/src/app/providers/app-config/app-config.ts
+++ b/src/app/providers/app-config/app-config.ts
@@ -129,11 +129,14 @@ export class AppConfigProvider {
           ? await this.getCachedRemoteConfig()
           : this.environmentFile as LocalEnvironmentFile;
 
-        // Re-bind local and remote configs
-        if (!!remoteConfig) this.mapRemoteConfig(remoteConfig);
+        // Validate the config
+        const result: ValidatorResult = this.schemaValidatorProvider.validateRemoteConfig(remoteConfig);
+
+        // Re-bind local and remote configs if valid
+        if (!!remoteConfig && result?.errors?.length === 0) this.mapRemoteConfig(remoteConfig);
 
       } catch (err) {
-        this.logError('Get app config async has thrown an error', err);
+        this.logError('Get app config async', err);
       }
     }
     return this.appConfig;

--- a/src/app/providers/authentication/__tests__/authentication.spec.ts
+++ b/src/app/providers/authentication/__tests__/authentication.spec.ts
@@ -171,7 +171,7 @@ describe('AuthenticationProvider', () => {
         .not
         .toHaveBeenCalled();
       expect(isAuthenticated)
-        .toEqual(false);
+        .toEqual(true);
     });
 
     /* Test passes, although due to code it throws an error which might lead to further confusion, but can be enabled

--- a/src/app/providers/authentication/authentication.ts
+++ b/src/app/providers/authentication/authentication.ts
@@ -139,11 +139,14 @@ export class AuthenticationProvider {
   };
 
   async hasValidToken(): Promise<boolean> {
-    if (this.isInUnAuthenticatedMode()) {
-      return Promise.resolve(true);
-    }
-    // refresh token if required
     try {
+      // evaluate network status before trying to interact with auth connect methods;
+      this.determineAuthenticationMode();
+      // if in un-authenticated mode, allow user to continue locally
+      if (this.isInUnAuthenticatedMode()) {
+        return true;
+      }
+      // refresh token when required
       await this.ionicAuth.isAuthenticated();
       await this.refreshTokenIfExpired();
       const token = await this.ionicAuth.getIdToken();
@@ -166,6 +169,7 @@ export class AuthenticationProvider {
       this.store$.dispatch(SaveLog({
         payload: this.logHelper.createLog(LogType.ERROR, 'refreshTokenIfExpired error', error),
       }));
+      throw error;
     }
   }
 

--- a/src/app/providers/data-store/__tests__/data-store.spec.ts
+++ b/src/app/providers/data-store/__tests__/data-store.spec.ts
@@ -113,8 +113,12 @@ describe('DataStoreProvider', () => {
         .and
         .returnValue(Promise.reject('error'));
 
-      expect(await provider.setItem(null, null))
-        .toEqual('error');
+      try {
+        await provider.setItem(null, null);
+      } catch (err) {
+        expect(err)
+          .toEqual('error');
+      }
     });
   });
   describe('removeItem', () => {

--- a/src/app/providers/device/__mocks__/device.mock.ts
+++ b/src/app/providers/device/__mocks__/device.mock.ts
@@ -55,4 +55,8 @@ export class DeviceProviderMock implements IDeviceProvider {
   is8thGenDevice = jasmine.createSpy('is8thGenDevice')
     .and
     .returnValue(true);
+
+  isSAMEnabled = jasmine.createSpy('isSAMEnabled')
+    .and
+    .returnValue(Promise.resolve(true));
 }

--- a/src/app/providers/logs/__tests__/logs-helper.spec.ts
+++ b/src/app/providers/logs/__tests__/logs-helper.spec.ts
@@ -2,6 +2,8 @@ import { TestBed } from '@angular/core/testing';
 import { Store, StoreModule } from '@ngrx/store';
 import { LogType } from '@shared/models/log.model';
 import { LogHelper } from '../logs-helper';
+import { NetworkStateProvider } from '@providers/network-state/network-state';
+import { NetworkStateProviderMock } from '@providers/network-state/__mocks__/network-state.mock';
 
 describe('LogHelper', () => {
   let logHelper: LogHelper;
@@ -18,6 +20,10 @@ describe('LogHelper', () => {
       providers: [
         LogHelper,
         Store,
+        {
+          provide: NetworkStateProvider,
+          useClass: NetworkStateProviderMock,
+        },
       ],
     });
 

--- a/src/app/providers/logs/logs-helper.ts
+++ b/src/app/providers/logs/logs-helper.ts
@@ -8,6 +8,7 @@ import { from, merge } from 'rxjs';
 import { Log, LogType } from '@shared/models/log.model';
 import { StoreModel } from '@shared/models/store.model';
 import { selectEmployeeId, selectVersionNumber } from '@store/app-info/app-info.selectors';
+import { ConnectionStatus, NetworkStateProvider } from '@providers/network-state/network-state';
 
 @Injectable()
 export class LogHelper {
@@ -18,7 +19,11 @@ export class LogHelper {
   private deviceInfo: DeviceInfo;
   private battery: number;
 
-  constructor(private store$: Store<StoreModel>) {
+  constructor(
+    private store$: Store<StoreModel>,
+    private networkStateProvider: NetworkStateProvider,
+  ) {
+
     const versionNumber$ = this.store$.pipe(
       select(selectVersionNumber),
       map((appVersion) => {
@@ -64,6 +69,7 @@ export class LogHelper {
       deviceId: this.deviceId,
       drivingExaminerId: this.employeeId,
       metaData: {
+        online: this.networkStateProvider.getNetworkState() === ConnectionStatus.ONLINE,
         batteryLevel: this.battery,
         memUsed: this.deviceInfo?.memUsed,
         realDiskFree: this.deviceInfo?.realDiskFree,

--- a/src/app/providers/slot/slot.ts
+++ b/src/app/providers/slot/slot.ts
@@ -1,12 +1,8 @@
 import { Injectable } from '@angular/core';
-import { DeepDiff } from 'deep-diff';
-import {
-  flatten, times, isEmpty, get, groupBy,
-} from 'lodash';
+import DeepDiff from 'deep-diff';
+import { flatten, get, groupBy, isEmpty, times } from 'lodash';
 import { Store } from '@ngrx/store';
-import {
-  ExaminerWorkSchedule, NonTestActivity, PersonalCommitment, TestSlot,
-} from '@dvsa/mes-journal-schema';
+import { ExaminerWorkSchedule, NonTestActivity, PersonalCommitment, TestSlot } from '@dvsa/mes-journal-schema';
 import { StoreModel } from '@shared/models/store.model';
 import { DateTime, Duration } from '@shared/helpers/date-time';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
@@ -37,40 +33,45 @@ export class SlotProvider {
 
     const oldJournalSlots: SlotItem[] = flatten(Object.values(slots));
 
-    newSlots.sort((slotA, slotB) => (slotA.slotDetail.start < slotB.slotDetail.start ? -1 : 1));
+    return newSlots
+      .sort((slotA, slotB) => (slotA.slotDetail.start < slotB.slotDetail.start ? -1 : 1))
+      .map((newSlot) => {
+        const newSlotId = newSlot.slotDetail.slotId;
 
-    return newSlots.map((newSlot) => {
-      const newSlotId = newSlot.slotDetail.slotId;
+        const replacedJournalSlot = oldJournalSlots.find((oldSlot) => oldSlot.slotData.slotDetail.slotId === newSlotId);
 
-      const replacedJournalSlot = oldJournalSlots.find((oldSlot) => oldSlot.slotData.slotDetail.slotId === newSlotId);
+        let differenceFound = false;
+        let hasSeenCandidateDetails = false;
 
-      let differenceFound = false;
-      let hasSeenCandidateDetails = false;
-      if (replacedJournalSlot) {
-        differenceFound = replacedJournalSlot.hasSlotChanged;
-        hasSeenCandidateDetails = replacedJournalSlot.hasSeenCandidateDetails;
-        const differenceToSlot = DeepDiff(replacedJournalSlot.slotData, newSlot);
-        if (Array.isArray(differenceToSlot) && differenceToSlot.some((change) => change.kind === 'E')) {
-          this.store$.dispatch(SlotHasChanged(newSlotId));
-          differenceFound = true;
+        if (replacedJournalSlot) {
+
+          differenceFound = replacedJournalSlot.hasSlotChanged;
+          hasSeenCandidateDetails = replacedJournalSlot.hasSeenCandidateDetails;
+
+          const differenceToSlot = DeepDiff(replacedJournalSlot.slotData, newSlot);
+
+          // 'E' - indicated a property was edited
+          if (Array.isArray(differenceToSlot) && differenceToSlot.some((change) => change.kind === 'E')) {
+            this.store$.dispatch(SlotHasChanged(newSlotId));
+            differenceFound = true;
+          }
         }
-      }
 
-      let personalCommitment: PersonalCommitment[] = null;
-      if (!isEmpty(newJournal.personalCommitments)) {
-        personalCommitment = newJournal.personalCommitments.filter(
-          (commitment) => Number(commitment.slotId) === Number(newSlotId),
-        );
-      }
+        let personalCommitment: PersonalCommitment[] = null;
+        if (!isEmpty(newJournal.personalCommitments)) {
+          personalCommitment = newJournal.personalCommitments.filter(
+            (commitment) => Number(commitment.slotId) === Number(newSlotId),
+          );
+        }
 
-      // add personalCommitment information to SlotItem, component and activityCode set to null
-      // as they are not constructed at this stage.
-      return new SlotItem(newSlot, differenceFound, hasSeenCandidateDetails, null, null, personalCommitment);
-    });
+        // add personalCommitment information to SlotItem, component and activityCode set to null
+        // as they are not constructed at this stage.
+        return new SlotItem(newSlot, differenceFound, hasSeenCandidateDetails, null, null, personalCommitment);
+      });
   }
 
   /**
-   * Extends the journal with empty days where there was no slots defined in the next 7 days
+   * Extends the journal with empty days when there were no slots defined in the next 7 days
    * @param slots Journal slots
    * @returns Slots with additional empty days
    */
@@ -79,10 +80,15 @@ export class SlotProvider {
 
     const days = times(
       numberOfDaysToView,
-      (d: number): string => this.dateTimeProvider.now().add(d, Duration.DAY).format('YYYY-MM-DD'),
+      (d: number): string => this.dateTimeProvider.now()
+        .add(d, Duration.DAY)
+        .format('YYYY-MM-DD'),
     );
-    // eslint-disable-next-line @typescript-eslint/no-shadow
-    const emptyDays = days.reduce((days: { [k: string]: SlotItem[] }, day: string) => ({ ...days, [day]: [] }), {});
+
+    const emptyDays = days.reduce((d: { [k: string]: SlotItem[] }, day: string) => ({
+      ...d,
+      [day]: [],
+    }), {});
 
     return {
       ...emptyDays,
@@ -105,7 +111,9 @@ export class SlotProvider {
       );
   };
 
-  getSlotDate = (slot: SlotItem): string => DateTime.at(slot.slotData.slotDetail.start).format('YYYY-MM-DD');
+  getSlotDate = (slot: SlotItem): string => DateTime
+    .at(slot.slotData.slotDetail.start)
+    .format('YYYY-MM-DD');
 
   canStartTest(testSlot: TestSlot): boolean {
     const { testPermissionPeriods } = this.appConfigProvider.getAppConfig().journal;
@@ -175,7 +183,8 @@ export class SlotProvider {
   getLatestViewableSlotDateTime(): Date {
     const today = moment();
     // add 3 days if current day is friday, 2 if saturday, else add 1
-    let daysToAdd;
+    let daysToAdd: moment.DurationInputArg1;
+
     if (today.isoWeekday() === 5) {
       daysToAdd = 3;
     } else {

--- a/src/app/shared/classes/__tests__/base-page.spec.ts
+++ b/src/app/shared/classes/__tests__/base-page.spec.ts
@@ -1,6 +1,4 @@
-import {
-  waitForAsync, fakeAsync, flushMicrotasks, TestBed,
-} from '@angular/core/testing';
+import { fakeAsync, flushMicrotasks, TestBed, waitForAsync } from '@angular/core/testing';
 import { Platform } from '@ionic/angular';
 import { Router } from '@angular/router';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
@@ -19,16 +17,27 @@ describe('BasePageComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: Router, useClass: RouterMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
       ],
     });
 
     platform = TestBed.inject(Platform);
     authenticationProvider = TestBed.inject(AuthenticationProvider);
     router = TestBed.inject(Router);
-    router.navigate = jasmine.createSpy().and.returnValue(Promise.resolve(true));
+    router.navigate = jasmine.createSpy()
+      .and
+      .returnValue(Promise.resolve(true));
 
     class BasePageClass extends BasePageComponent {
       constructor(
@@ -47,14 +56,20 @@ describe('BasePageComponent', () => {
     it('should allow user access if authentication is not required', fakeAsync(() => {
       basePageComponent.loginRequired = false;
       basePageComponent.ionViewWillEnter();
-      expect(router.navigate).not.toHaveBeenCalled();
+      expect(router.navigate)
+        .not
+        .toHaveBeenCalled();
       flushMicrotasks();
     }));
 
     it('should allow user access if authentication is required and device is not ios', fakeAsync(() => {
-      basePageComponent.isIos = jasmine.createSpy().and.returnValue(false);
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(false);
       basePageComponent.ionViewWillEnter();
-      expect(router.navigate).not.toHaveBeenCalled();
+      expect(router.navigate)
+        .not
+        .toHaveBeenCalled();
       flushMicrotasks();
     }));
 
@@ -62,59 +77,88 @@ describe('BasePageComponent', () => {
       authenticationProvider.hasValidToken = jasmine.createSpy(
         'authenticationProvider.hasValidToken',
       )
-        .and.returnValue(Promise.resolve(false));
+        .and
+        .returnValue(Promise.resolve(false));
       basePageComponent.ionViewWillEnter();
-      expect(router.navigate).not.toHaveBeenCalled();
+      expect(router.navigate)
+        .not
+        .toHaveBeenCalled();
       flushMicrotasks();
     }));
     it('should not allow access if user is not authd, auth is required and is ios', fakeAsync(() => {
-      basePageComponent.isIos = jasmine.createSpy().and.returnValue(true);
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(true);
       authenticationProvider.hasValidToken = jasmine.createSpy('authenticationProvider.hasValidToken')
-        .and.returnValue(Promise.resolve(false));
+        .and
+        .returnValue(Promise.resolve(false));
       authenticationProvider.isInUnAuthenticatedMode = jasmine
         .createSpy('authenticationProvider.isInUnAuthenticatedMode')
-        .and.returnValue(false);
+        .and
+        .returnValue(false);
 
       basePageComponent.loginRequired = true;
       basePageComponent.ionViewWillEnter();
       flushMicrotasks();
-      expect(router.navigate).toHaveBeenCalledWith([LOGIN_PAGE], { replaceUrl: true });
+      expect(router.navigate)
+        .toHaveBeenCalledWith([LOGIN_PAGE], { replaceUrl: true,
+          state: {
+            hasLoggedOut: false,
+            invalidToken: true,
+          },
+        });
     }));
 
   });
 
   describe('isIos()', () => {
     it('should return true if platform is ios', () => {
-      platform.is = jasmine.createSpy('platform.is').and.returnValue(true);
-      expect(basePageComponent.isIos()).toBe(true);
+      platform.is = jasmine.createSpy('platform.is')
+        .and
+        .returnValue(true);
+      expect(basePageComponent.isIos())
+        .toBe(true);
     });
     it('should return false if platform is not ios', () => {
-      platform.is = jasmine.createSpy('platform.is').and.returnValue(false);
-      expect(basePageComponent.isIos()).toBe(false);
+      platform.is = jasmine.createSpy('platform.is')
+        .and
+        .returnValue(false);
+      expect(basePageComponent.isIos())
+        .toBe(false);
     });
   });
 
   describe('logout()', () => {
     it('should try to logout when platform is ios', async () => {
-      basePageComponent.isIos = jasmine.createSpy().and.returnValue(true);
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(true);
       authenticationProvider.logout = jasmine.createSpy('authenticationProvider.logout')
-        .and.returnValue(Promise.resolve());
+        .and
+        .returnValue(Promise.resolve());
       await basePageComponent.logout();
-      expect(authenticationProvider.logout).toHaveBeenCalledTimes(1);
-      expect(router.navigate).toHaveBeenCalledTimes(1);
-      expect(router.navigate).toHaveBeenCalledWith([LOGIN_PAGE], {
-        replaceUrl: true,
-        state: {
-          hasLoggedOut: true,
-        },
-      });
+      expect(authenticationProvider.logout)
+        .toHaveBeenCalledTimes(1);
+      expect(router.navigate)
+        .toHaveBeenCalledTimes(1);
+      expect(router.navigate)
+        .toHaveBeenCalledWith([LOGIN_PAGE], {
+          replaceUrl: true,
+          state: {
+            hasLoggedOut: true,
+          },
+        });
     });
     // @TODO MES-7133 fix intermittently failing test
     xit('should not try to logout when platform is not ios', async () => {
-      basePageComponent.isIos = jasmine.createSpy().and.returnValue(false);
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(false);
       await basePageComponent.logout();
-      expect(authenticationProvider.logout).toHaveBeenCalledTimes(0);
-      expect(router.navigate).toHaveBeenCalledTimes(0);
+      expect(authenticationProvider.logout)
+        .toHaveBeenCalledTimes(0);
+      expect(router.navigate)
+        .toHaveBeenCalledTimes(0);
     });
   });
 

--- a/src/app/shared/classes/base-page.ts
+++ b/src/app/shared/classes/base-page.ts
@@ -25,8 +25,6 @@ export abstract class BasePageComponent {
    */
   ionViewWillEnter() {
     if (this.isIos()) {
-      // evaluate network status before trying to interact with auth connect methods;
-      this.authenticationProvider.determineAuthenticationMode();
       this.authenticationProvider
         .hasValidToken()
         .then(async (hasValidToken) => {

--- a/src/app/shared/classes/base-page.ts
+++ b/src/app/shared/classes/base-page.ts
@@ -31,7 +31,14 @@ export abstract class BasePageComponent {
         .hasValidToken()
         .then(async (hasValidToken) => {
           if (this.loginRequired && !hasValidToken && !this.authenticationProvider.isInUnAuthenticatedMode()) {
-            await this.router.navigate([LOGIN_PAGE], { replaceUrl: true });
+            const navigationExtras: NavigationExtras = {
+              replaceUrl: true,
+              state: {
+                hasLoggedOut: false,
+                invalidToken: true,
+              },
+            };
+            await this.router.navigate([LOGIN_PAGE], navigationExtras);
           }
         });
     }

--- a/src/app/shared/classes/test-flow-base-pages/waiting-room-to-car/waiting-room-to-car-base-page.ts
+++ b/src/app/shared/classes/test-flow-base-pages/waiting-room-to-car/waiting-room-to-car-base-page.ts
@@ -20,7 +20,6 @@ import { getGearboxCategory, getRegistrationNumber } from '@store/tests/vehicle-
 import { TEST_CENTRE_JOURNAL_PAGE, TestFlowPageNames } from '@pages/page-names.constants';
 import { RouteByCategoryProvider } from '@providers/route-by-category/route-by-category';
 import {
-  GetMotStatus,
   WaitingRoomToCarBikeCategoryChanged,
   WaitingRoomToCarBikeCategorySelected,
   WaitingRoomToCarViewDidEnter,
@@ -66,7 +65,8 @@ import { CompetencyOutcome } from '@shared/models/competency-outcome';
 import { PracticeableBasePageComponent } from '@shared/classes/practiceable-base-page';
 import { PopulateTestCategory } from '@store/tests/category/category.actions';
 import {
-  OrditTrainedChanged, TrainerRegistrationNumberChanged,
+  OrditTrainedChanged,
+  TrainerRegistrationNumberChanged,
   TrainingRecordsChanged,
 } from '@store/tests/trainer-details/cat-adi-part2/trainer-details.cat-adi-part2.actions';
 import {
@@ -240,7 +240,8 @@ export abstract class WaitingRoomToCarBasePageComponent extends PracticeableBase
   }
 
   getMOTStatus(): void {
-    this.store$.dispatch(GetMotStatus());
+    // Temporarily disable the call to the MOT endpoint as it's not being used.
+    // this.store$.dispatch(GetMotStatus());
   }
 
   schoolCarToggled(): void {
@@ -282,7 +283,12 @@ export abstract class WaitingRoomToCarBasePageComponent extends PracticeableBase
   }
 
   generateDelegatedQuestionResults(number: number, outcome: CompetencyOutcome): QuestionResult[] {
-    return Array(number).fill(null).map(() => ({ outcome, code: 'DEL' }));
+    return Array(number)
+      .fill(null)
+      .map(() => ({
+        outcome,
+        code: 'DEL',
+      }));
   }
 
   closeVehicleChecksModal(): void {

--- a/src/components/test-slot/test-slot/test-slot.ts
+++ b/src/components/test-slot/test-slot/test-slot.ts
@@ -66,22 +66,13 @@ export class TestSlotComponent implements SlotComponent, OnInit {
   teamJournalCandidateResult: boolean = false;
 
   @Input()
-  derivedTestStatus: TestStatus | null = null;
-
-  @Input()
-  derivedActivityCode: ActivityCode | null = null;
-
-  @Input()
-  derivedPassCertificate?: string;
-
-  @Input()
   examinerName: string = null;
 
   @Input()
   isTeamJournal: boolean = false;
 
   @Input()
-  isPracticeMode?: boolean = false;
+  isPracticeMode: boolean = false;
 
   @Input()
   isPortrait: boolean = false;
@@ -110,22 +101,23 @@ export class TestSlotComponent implements SlotComponent, OnInit {
 
   ngOnInit(): void {
     const { slotId } = this.slot.slotDetail;
+
     this.componentState = {
       testStatus$: this.store$.pipe(
         select(getTests),
-        select((tests) => this.derivedTestStatus || getTestStatus(tests, slotId)),
+        select((tests) => getTestStatus(tests, slotId)),
       ),
       testActivityCode$: this.store$.pipe(
         select(getTests),
-        map((tests) => this.derivedActivityCode || getActivityCodeBySlotId(tests, slotId)),
+        map((tests) => getActivityCodeBySlotId(tests, slotId)),
       ),
       testPassCertificate$: this.store$.pipe(
         select(getTests),
-        map((tests) => this.derivedPassCertificate || getPassCertificateBySlotId(tests, slotId)),
+        map((tests) => getPassCertificateBySlotId(tests, slotId)),
       ),
       isRekey$: this.store$.pipe(
         select(getTests),
-        map((tests) => getTestById(tests, this.slot.slotDetail.slotId.toString())),
+        map((tests) => getTestById(tests, slotId?.toString())),
         filter((test) => test !== undefined),
         select(getRekeyIndicator),
         select(isRekey),
@@ -134,7 +126,6 @@ export class TestSlotComponent implements SlotComponent, OnInit {
 
     this.canViewCandidateDetails = this.slotProvider.canViewCandidateDetails(this.slot);
     this.isTestCentreJournalADIBooking = this.slotProvider.isTestCentreJournalADIBooking(this.slot, this.isTeamJournal);
-
   }
 
   getColSize(): string {


### PR DESCRIPTION
## Description
- Stop unloading of Journal/Tests on logout
- Re-instate`logoutClearsTestPersistence`
- Remove derived data logic which was dependent on `CompletedTests`
- Remove call to `GetMotStatus` - not being used, performance implications for no EU reward
- Add logs to Auth and DataStore providers

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
