### PR TITLE
Lock / Unlock device in BasePage

### DIFF
--- a/mock/angular-mocks/activated-route.mock.ts
+++ b/mock/angular-mocks/activated-route.mock.ts
@@ -1,0 +1,7 @@
+export class ActivatedRouteMock {
+  snapshot = {
+    ['_routerState']: {
+      url: '/test',
+    },
+  };
+}

--- a/mock/angular-mocks/router-mock.ts
+++ b/mock/angular-mocks/router-mock.ts
@@ -1,6 +1,8 @@
 export class RouterMock {
   url = '/url';
 
+  routerState = { root: '' };
+
   navigate = jasmine.createSpy('navigate')
     .and
     .returnValue(Promise.resolve(true));

--- a/mock/index.mock.ts
+++ b/mock/index.mock.ts
@@ -1,6 +1,7 @@
 export * from '@mocks/@capacitor/biometrics';
 export * from '@mocks/@capacitor/splash-screen';
 export * from '@mocks/@capacitor/status-bar';
+export * from '@mocks/angular-mocks/activated-route.mock';
 export * from '@mocks/angular-mocks/dom-sanitizer.mock';
 export * from '@mocks/angular-mocks/nav-params.mock';
 export * from '@mocks/angular-mocks/router-mock';

--- a/src/app/__tests__/app.component.spec.ts
+++ b/src/app/__tests__/app.component.spec.ts
@@ -2,8 +2,14 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { ComponentFixture, fakeAsync, flushMicrotasks, TestBed, waitForAsync } from '@angular/core/testing';
 import { AlertController, MenuController, Platform } from '@ionic/angular';
 import { Store, StoreModule } from '@ngrx/store';
-import { Router } from '@angular/router';
-import { AlertControllerMock, MenuControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
+import { ActivatedRoute, Router } from '@angular/router';
+import {
+  ActivatedRouteMock,
+  AlertControllerMock,
+  MenuControllerMock,
+  PlatformMock,
+  RouterMock,
+} from '@mocks/index.mock';
 import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { Capacitor } from '@capacitor/core';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
@@ -34,6 +40,8 @@ import { AccessibilityServiceMock } from '@providers/accessibility/__mocks__/acc
 import { LOGIN_PAGE } from '@pages/page-names.constants';
 import { AppComponent } from '../app.component';
 import { StorageMock } from '@mocks/ionic-mocks/storage.mock';
+import { LogHelper } from '@providers/logs/logs-helper';
+import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -119,6 +127,14 @@ describe('AppComponent', () => {
         {
           provide: Storage,
           useClass: StorageMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: ActivatedRouteMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
         },
       ],
     });

--- a/src/app/__tests__/sentry-error-handler.spec.ts
+++ b/src/app/__tests__/sentry-error-handler.spec.ts
@@ -48,9 +48,9 @@ describe('SentryIonicErrorHandler', () => {
 
     spyOn(SentryIonicErrorHandler.prototype, 'handleError');
     spyOn(sentryErrorHandler.store$, 'dispatch');
-    spyOn(sentryErrorHandler.authenticationProvider, 'getEmployeeId')
-      .and
-      .returnValue(mockLog.drivingExaminerId);
+    // spyOn(sentryErrorHandler.authenticationProvider, 'getEmployeeIdFromIDToken')
+    //   .and
+    //   .returnValue(mockLog.drivingExaminerId);
     spyOn(sentryErrorHandler.appConfigProvider, 'getAppConfig')
       .and
       .returnValue({
@@ -71,7 +71,7 @@ describe('SentryIonicErrorHandler', () => {
         .toHaveBeenCalled();
       expect(sentryErrorHandler.appInfoProvider.getFullVersionNumber)
         .toHaveBeenCalled();
-      expect(sentryErrorHandler.authenticationProvider.getEmployeeId)
+      expect(sentryErrorHandler.authenticationProvider.getEmployeeIdFromIDToken)
         .toHaveBeenCalled();
       expect(sentryErrorHandler.store$.dispatch)
         .not
@@ -92,7 +92,7 @@ describe('SentryIonicErrorHandler', () => {
         .toHaveBeenCalled();
       expect(sentryErrorHandler.appInfoProvider.getFullVersionNumber)
         .toHaveBeenCalled();
-      expect(sentryErrorHandler.authenticationProvider.getEmployeeId)
+      expect(sentryErrorHandler.authenticationProvider.getEmployeeIdFromIDToken)
         .toHaveBeenCalled();
       expect(sentryErrorHandler.store$.dispatch)
         .toHaveBeenCalledWith(SaveLog({ payload: mockLog }));

--- a/src/app/__tests__/sentry-error-handler.spec.ts
+++ b/src/app/__tests__/sentry-error-handler.spec.ts
@@ -48,9 +48,6 @@ describe('SentryIonicErrorHandler', () => {
 
     spyOn(SentryIonicErrorHandler.prototype, 'handleError');
     spyOn(sentryErrorHandler.store$, 'dispatch');
-    // spyOn(sentryErrorHandler.authenticationProvider, 'getEmployeeIdFromIDToken')
-    //   .and
-    //   .returnValue(mockLog.drivingExaminerId);
     spyOn(sentryErrorHandler.appConfigProvider, 'getAppConfig')
       .and
       .returnValue({

--- a/src/app/__tests__/sentry-error-handler.spec.ts
+++ b/src/app/__tests__/sentry-error-handler.spec.ts
@@ -46,16 +46,15 @@ describe('SentryIonicErrorHandler', () => {
 
     sentryErrorHandler = TestBed.inject(SentryIonicErrorHandler);
 
-    spyOn(SentryIonicErrorHandler.prototype, 'handleError');
     spyOn(sentryErrorHandler.store$, 'dispatch');
-    spyOn(sentryErrorHandler.appConfigProvider, 'getAppConfig')
+    spyOn(sentryErrorHandler.appConfigProvider, 'getAppConfigAsync')
       .and
-      .returnValue({
+      .returnValue(Promise.resolve({
         role: ExaminerRole.DE,
-      } as AppConfig);
+      } as AppConfig));
   }));
 
-  describe('handleErr', () => {
+  describe('handleError', () => {
     it('should call through to all providers and pass error to Sentry', async () => {
       spyOn(sentryErrorHandler.appInfoProvider, 'getFullVersionNumber')
         .and
@@ -63,8 +62,8 @@ describe('SentryIonicErrorHandler', () => {
           Promise.resolve('4.8.0.5'),
         );
 
-      await sentryErrorHandler.handleErr(new Error('Some runtime error'));
-      expect(sentryErrorHandler.appConfigProvider.getAppConfig)
+      await sentryErrorHandler.handleError(new Error('Some runtime error'));
+      expect(sentryErrorHandler.appConfigProvider.getAppConfigAsync)
         .toHaveBeenCalled();
       expect(sentryErrorHandler.appInfoProvider.getFullVersionNumber)
         .toHaveBeenCalled();
@@ -84,8 +83,8 @@ describe('SentryIonicErrorHandler', () => {
         .and
         .returnValue(mockLog);
 
-      await sentryErrorHandler.handleErr(new Error('Some runtime error'));
-      expect(sentryErrorHandler.appConfigProvider.getAppConfig)
+      await sentryErrorHandler.handleError(new Error('Some runtime error'));
+      expect(sentryErrorHandler.appConfigProvider.getAppConfigAsync)
         .toHaveBeenCalled();
       expect(sentryErrorHandler.appInfoProvider.getFullVersionNumber)
         .toHaveBeenCalled();
@@ -104,16 +103,16 @@ describe('SentryIonicErrorHandler', () => {
         .and
         .returnValue(mockLog);
 
-      await sentryErrorHandler.handleErr({ err: 'some error' });
+      await sentryErrorHandler.handleError({ err: 'some error' });
       expect(sentryErrorHandler.store$.dispatch)
         .toHaveBeenCalledWith(SaveLog({ payload: mockLog }));
     });
     it('should not call to any provider if an instance of HttpErrorResponse', async () => {
-      await sentryErrorHandler.handleErr(new HttpErrorResponse({
+      await sentryErrorHandler.handleError(new HttpErrorResponse({
         status: 403,
         url: 'https://logs-service.com',
       }));
-      expect(sentryErrorHandler.appConfigProvider.getAppConfig)
+      expect(sentryErrorHandler.appConfigProvider.getAppConfigAsync)
         .not
         .toHaveBeenCalled();
     });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,10 +1,9 @@
 import { Component, Injector, OnInit } from '@angular/core';
 import { map } from 'rxjs/operators';
-import { Store } from '@ngrx/store';
 
 import { StatusBar, Style } from '@capacitor/status-bar';
 import { MenuController } from '@ionic/angular';
-import {  combineLatest, merge, Observable, Subscription } from 'rxjs';
+import { combineLatest, merge, Observable, Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import * as Sentry from '@sentry/capacitor';
 import { BrowserTracing, init as sentryAngularInit } from '@sentry/angular-ivy';
@@ -12,7 +11,6 @@ import { Storage } from '@ionic/storage-angular';
 
 import { DataStoreProvider } from '@providers/data-store/data-store';
 import { NetworkStateProvider } from '@providers/network-state/network-state';
-import { StoreModel } from '@shared/models/store.model';
 import { LogoutBasePageComponent } from '@shared/classes/logout-base-page';
 import { AppResumed, AppSuspended, LoadAppVersion } from '@store/app-info/app-info.actions';
 import { selectLogoutEnabled } from '@store/app-config/app-config.selectors';
@@ -20,7 +18,6 @@ import { Capacitor } from '@capacitor/core';
 import { AppInfoProvider } from '@providers/app-info/app-info';
 import { AppConfigProvider } from '@providers/app-config/app-config';
 import { SENTRY_ERRORS } from '@app/sentry-error-handler';
-import { DeviceProvider } from '@providers/device/device';
 import { DASHBOARD_PAGE, LOGIN_PAGE, UNUPLOADED_TESTS_PAGE } from '@pages/page-names.constants';
 import { SideMenuClosed, SideMenuItemSelected, SideMenuOpened } from '@pages/dashboard/dashboard.actions';
 import { SlotProvider } from '@providers/slot/slot';
@@ -73,7 +70,6 @@ export class AppComponent extends LogoutBasePageComponent implements OnInit {
   private platformSubscription: Subscription;
 
   constructor(
-    private store$: Store<StoreModel>,
     private slotProvider: SlotProvider,
     private dateTimeProvider: DateTimeProvider,
     protected accessibilityService: AccessibilityService,
@@ -83,7 +79,6 @@ export class AppComponent extends LogoutBasePageComponent implements OnInit {
     protected translate: TranslateService,
     protected appInfo: AppInfoProvider,
     protected appConfigProvider: AppConfigProvider,
-    protected deviceProvider: DeviceProvider,
     private storage: Storage,
     injector: Injector,
   ) {

--- a/src/app/pages/back-to-office/__tests__/back-to-office.page.spec.ts
+++ b/src/app/pages/back-to-office/__tests__/back-to-office.page.spec.ts
@@ -1,6 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule, ModalController } from '@ionic/angular';
-import { KeepAwake as Insomnia } from '@capacitor-community/keep-awake';
 import { AppModule } from 'src/app/app.module';
 import { Store, StoreModule } from '@ngrx/store';
 import { StoreModel } from '@shared/models/store.model';
@@ -14,7 +13,6 @@ import { RouteByCategoryProvider } from '@providers/route-by-category/route-by-c
 import { RouteByCategoryProviderMock } from '@providers/route-by-category/__mocks__/route-by-category.mock';
 import { ModalControllerMock } from '@mocks/ionic-mocks/modal-controller.mock';
 import { BasePageComponent } from '@shared/classes/base-page';
-import { ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
 import { BackToOfficePage, NavigationTarget } from '../back-to-office.page';
 import { JOURNAL_PAGE } from '@pages/page-names.constants';
 
@@ -23,7 +21,6 @@ describe('BackToOfficePage', () => {
   let component: BackToOfficePage;
   let modalController: ModalController;
   let store$: Store<StoreModel>;
-  let deviceProvider: DeviceProvider;
   let routeByCategoryProvider: RouteByCategoryProvider;
 
   beforeEach(waitForAsync(() => {
@@ -55,7 +52,6 @@ describe('BackToOfficePage', () => {
 
     fixture = TestBed.createComponent(BackToOfficePage);
     component = fixture.componentInstance;
-    deviceProvider = TestBed.inject(DeviceProvider);
     modalController = TestBed.inject(ModalController);
     store$ = TestBed.inject(Store);
     routeByCategoryProvider = TestBed.inject(RouteByCategoryProvider);
@@ -71,19 +67,9 @@ describe('BackToOfficePage', () => {
   describe('Class', () => {
     describe('ionViewDidEnter', () => {
       it('should disable test inhibitions when in practice mode', async () => {
-        spyOn(ScreenOrientation, 'unlock')
-          .and
-          .returnValue(Promise.resolve());
-        spyOn(Insomnia, 'allowSleep')
-          .and
-          .returnValue(Promise.resolve());
+        spyOn(BasePageComponent.prototype, 'unlockDevice');
         await component.ionViewDidEnter();
-        expect(deviceProvider.disableSingleAppMode)
-          .not
-          .toHaveBeenCalled();
-        expect(ScreenOrientation.unlock)
-          .toHaveBeenCalled();
-        expect(Insomnia.allowSleep)
+        expect(BasePageComponent.prototype.unlockDevice)
           .toHaveBeenCalled();
       });
     });

--- a/src/app/pages/candidate-licence/__tests__/candidate-licence.page.spec.ts
+++ b/src/app/pages/candidate-licence/__tests__/candidate-licence.page.spec.ts
@@ -2,12 +2,10 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Platform } from '@ionic/angular';
 import { provideMockStore } from '@ngrx/store/testing';
 import { MockComponent } from 'ng-mocks';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { RouterMock } from '@mocks/angular-mocks/router-mock';
 import { DomSanitizer } from '@angular/platform-browser';
-import {
-  FormControl, FormGroup, ReactiveFormsModule, Validators,
-} from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 
 import { CandidateLicencePage } from '@pages/candidate-licence/candidate-licence.page';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
@@ -37,6 +35,11 @@ import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { TestsModel } from '@store/tests/tests.model';
 import * as moment from 'moment';
+import { DeviceProvider } from '@providers/device/device';
+import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
+import { ActivatedRouteMock } from '@mocks/angular-mocks/activated-route.mock';
+import { LogHelper } from '@providers/logs/logs-helper';
+import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
 
 describe('CandidateLicencePage', () => {
   let component: CandidateLicencePage;
@@ -127,6 +130,18 @@ describe('CandidateLicencePage', () => {
         {
           provide: Router,
           useClass: RouterMock,
+        },
+        {
+          provide: DeviceProvider,
+          useClass: DeviceProviderMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: ActivatedRouteMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
         },
         provideMockStore({ initialState }),
       ],

--- a/src/app/pages/communication/__tests__/communication.page.spec.ts
+++ b/src/app/pages/communication/__tests__/communication.page.spec.ts
@@ -1,8 +1,6 @@
-import {
-  ComponentFixture, waitForAsync, TestBed, fakeAsync, tick,
-} from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { Platform } from '@ionic/angular';
-import { PlatformMock } from '@mocks/index.mock';
+import { PlatformMock, RouterMock } from '@mocks/index.mock';
 
 import { AppModule } from 'src/app/app.module';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
@@ -43,7 +41,6 @@ describe('CommunicationPage', () => {
   let component: CommunicationPage;
   let store$: Store<StoreModel>;
   let translate: TranslateService;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -90,11 +87,26 @@ describe('CommunicationPage', () => {
         })),
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: DeviceAuthenticationProvider, useClass: DeviceAuthenticationProviderMock },
-        { provide: DeviceProvider, useClass: DeviceProviderMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: DeviceAuthenticationProvider,
+          useClass: DeviceAuthenticationProviderMock,
+        },
+        {
+          provide: DeviceProvider,
+          useClass: DeviceProviderMock,
+        },
       ],
     });
 
@@ -147,7 +159,9 @@ describe('CommunicationPage', () => {
 
     describe('dispatchCandidateChoseNewEmail', () => {
       it('should dispatch a CandidateChoseEmailAsCommunicationPreference action', () => {
-        spyOn(component, 'isNewEmailSelected').and.returnValue(true);
+        spyOn(component, 'isNewEmailSelected')
+          .and
+          .returnValue(true);
         component.dispatchCandidateChoseNewEmail(candidateMock.emailAddress);
         expect(store$.dispatch)
           .toHaveBeenCalledWith(communicationPreferencesActions.CandidateChoseEmailAsCommunicationPreference(
@@ -217,14 +231,16 @@ describe('CommunicationPage', () => {
     it('should dispatch ValidPassCertChanged with passed value', () => {
       spyOn(component.store$, 'dispatch');
       component.validCertificateChanged(true);
-      expect(component.store$.dispatch).toHaveBeenCalledWith(ValidPassCertChanged(true));
+      expect(component.store$.dispatch)
+        .toHaveBeenCalledWith(ValidPassCertChanged(true));
     });
   });
 
   describe('ionViewDidEnter', () => {
     it('should dispatch an action', () => {
       component.ionViewDidEnter();
-      expect(store$.dispatch).toHaveBeenCalledWith(CommunicationViewDidEnter());
+      expect(store$.dispatch)
+        .toHaveBeenCalledWith(CommunicationViewDidEnter());
     });
   });
 
@@ -233,46 +249,53 @@ describe('CommunicationPage', () => {
       component.subscription = new Subscription();
       spyOn(component.subscription, 'unsubscribe');
       component.ionViewDidLeave();
-      expect(component.subscription.unsubscribe).toHaveBeenCalled();
+      expect(component.subscription.unsubscribe)
+        .toHaveBeenCalled();
     });
   });
 
   describe('shouldPreselectADefaultValue', () => {
     it('should return true if communicationType is equal to CommunicationPage.notProvided', () => {
       component.communicationType = CommunicationPage.notProvided;
-      expect(component.shouldPreselectADefaultValue()).toEqual(true);
+      expect(component.shouldPreselectADefaultValue())
+        .toEqual(true);
     });
     it('should return false if communicationType '
-        + 'is not equal to CommunicationPage.notProvided', () => {
+      + 'is not equal to CommunicationPage.notProvided', () => {
       component.communicationType = CommunicationPage.email;
-      expect(component.shouldPreselectADefaultValue()).toEqual(false);
+      expect(component.shouldPreselectADefaultValue())
+        .toEqual(false);
     });
   });
 
   describe('restoreRadioValidators', () => {
     it('should set radioCtrl to true', () => {
       component.restoreRadioValidators();
-      expect(component.form.controls['radioCtrl'].value).toEqual(true);
+      expect(component.form.controls['radioCtrl'].value)
+        .toEqual(true);
     });
   });
 
   describe('initialiseDefaultSelections', () => {
     it('should set communicationType to CommunicationPage.email', () => {
       component.initialiseDefaultSelections();
-      expect(component.communicationType).toEqual(CommunicationPage.email);
+      expect(component.communicationType)
+        .toEqual(CommunicationPage.email);
     });
     it('should set emailType to CommunicationPage.providedEmail '
-        + 'if candidateProvidedEmail is present', () => {
+      + 'if candidateProvidedEmail is present', () => {
       component.candidateProvidedEmail = 'test';
       component.initialiseDefaultSelections();
 
-      expect(component.emailType).toEqual(CommunicationPage.providedEmail);
+      expect(component.emailType)
+        .toEqual(CommunicationPage.providedEmail);
     });
     it('should set radioCtrl to true if candidateProvidedEmail is present', () => {
       component.candidateProvidedEmail = 'test';
       component.initialiseDefaultSelections();
 
-      expect(component.form.controls['radioCtrl'].value).toEqual(true);
+      expect(component.form.controls['radioCtrl'].value)
+        .toEqual(true);
     });
     it('should call dispatchCandidateChoseProvidedEmail if candidateProvidedEmail is present', () => {
       component.candidateProvidedEmail = 'test';
@@ -280,34 +303,40 @@ describe('CommunicationPage', () => {
 
       component.initialiseDefaultSelections();
 
-      expect(component.dispatchCandidateChoseProvidedEmail).toHaveBeenCalled();
+      expect(component.dispatchCandidateChoseProvidedEmail)
+        .toHaveBeenCalled();
     });
   });
 
   describe('assertEmailType', () => {
     it('should set emailType to CommunicationPage.providedEmail if communicationEmail'
-        + 'is equal to candidateProvidedEmail and candidateProvidedEmail is not blank', () => {
+      + 'is equal to candidateProvidedEmail and candidateProvidedEmail is not blank', () => {
       component.candidateProvidedEmail = 'test';
       component.communicationEmail = 'test';
       component.assertEmailType();
-      expect(component.emailType).toEqual(CommunicationPage.providedEmail);
+      expect(component.emailType)
+        .toEqual(CommunicationPage.providedEmail);
     });
     it('should set emailType to CommunicationPage.updatedEmail if communicationEmail'
-        + 'is not equal to candidateProvidedEmail', () => {
+      + 'is not equal to candidateProvidedEmail', () => {
       component.candidateProvidedEmail = 'test1';
       component.communicationEmail = 'test';
       component.assertEmailType();
-      expect(component.emailType).toEqual(CommunicationPage.updatedEmail);
+      expect(component.emailType)
+        .toEqual(CommunicationPage.updatedEmail);
     });
   });
 
   describe('conditionalDispatchCandidateChoseNewEmail', () => {
     it('should call dispatchCandidateChoseNewEmail if isNewEmailSelected is true and '
-        + 'communicationEmail is not empty', () => {
-      spyOn(component, 'isNewEmailSelected').and.returnValue(true);
+      + 'communicationEmail is not empty', () => {
+      spyOn(component, 'isNewEmailSelected')
+        .and
+        .returnValue(true);
       spyOn(component, 'dispatchCandidateChoseNewEmail');
       component.conditionalDispatchCandidateChoseNewEmail();
-      expect(component.dispatchCandidateChoseNewEmail).toHaveBeenCalled();
+      expect(component.dispatchCandidateChoseNewEmail)
+        .toHaveBeenCalled();
     });
   });
 
@@ -316,14 +345,17 @@ describe('CommunicationPage', () => {
       spyOn(component, 'assertEmailType');
       component.communicationType = CommunicationPage.email;
       component.restoreRadiosFromState();
-      expect(component.assertEmailType).toHaveBeenCalled();
+      expect(component.assertEmailType)
+        .toHaveBeenCalled();
     });
     it('should not call assertEmailType if communicationType '
-        + 'is not equal to CommunicationPage.email', () => {
+      + 'is not equal to CommunicationPage.email', () => {
       spyOn(component, 'assertEmailType');
       component.communicationType = CommunicationPage.notProvided;
       component.restoreRadiosFromState();
-      expect(component.assertEmailType).not.toHaveBeenCalled();
+      expect(component.assertEmailType)
+        .not
+        .toHaveBeenCalled();
     });
   });
 

--- a/src/app/pages/communication/communication.page.ts
+++ b/src/app/pages/communication/communication.page.ts
@@ -49,9 +49,6 @@ import {
   getValidCertificateStatus,
 } from '@store/tests/pre-test-declarations/cat-a-mod2/pre-test-declarations.cat-adi-part3.selector';
 import { ValidPassCertChanged } from '@store/tests/pre-test-declarations/pre-test-declarations.actions';
-import { OrientationType, ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
-import { KeepAwake as Insomnia } from '@capacitor-community/keep-awake';
-import { DeviceProvider } from '@providers/device/device';
 
 interface CommunicationPageState {
   candidateName$: Observable<string>;
@@ -100,7 +97,6 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
     public routeByCat: RouteByCategoryProvider,
     public deviceAuthenticationProvider: DeviceAuthenticationProvider,
     private translate: TranslateService,
-    private deviceProvider: DeviceProvider,
     injector: Injector,
   ) {
     super(injector, false);
@@ -220,27 +216,24 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
 
   async ionViewDidEnter(): Promise<void> {
     this.store$.dispatch(CommunicationViewDidEnter());
-
-    if (super.isIos()) {
-      await ScreenOrientation.lock({ type: OrientationType.PORTRAIT_PRIMARY });
-      await Insomnia.keepAwake();
-
-      if (!this.isEndToEndPracticeMode) {
-        await this.deviceProvider.enableSingleAppMode();
-      }
-    }
+    await super.lockDevice(this.isEndToEndPracticeMode);
   }
 
   async onSubmit(): Promise<void> {
     Object.keys(this.form.controls)
-      .forEach((controlName) => this.form.controls[controlName].markAsDirty());
+      .forEach(
+        (controlName) => this.form.controls[controlName].markAsDirty(),
+      );
+
     if (!this.form.valid) {
       Object.keys(this.form.controls)
-        .forEach((controlName) => {
-          if (this.form.controls[controlName].invalid) {
-            this.store$.dispatch(CommunicationValidationError(`${controlName} is blank`));
-          }
-        });
+        .forEach(
+          (controlName) => {
+            if (this.form.controls[controlName].invalid) {
+              this.store$.dispatch(CommunicationValidationError(`${controlName} is blank`));
+            }
+          },
+        );
       return;
     }
 

--- a/src/app/pages/dashboard/components/test-centre-journal-card/__tests__/test-centre-journal-card.spec.ts
+++ b/src/app/pages/dashboard/components/test-centre-journal-card/__tests__/test-centre-journal-card.spec.ts
@@ -1,14 +1,15 @@
-import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { CommonModule } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 import { Router } from '@angular/router';
 import { TEST_CENTRE_JOURNAL_PAGE } from '@pages/page-names.constants';
 import { TestCentreJournalCardComponent } from '../test-centre-journal-card';
+import { RouterMock } from '@mocks/angular-mocks/router-mock';
 
 describe('TestCentreJournalCard', () => {
   let component: TestCentreJournalCardComponent;
   let fixture: ComponentFixture<TestCentreJournalCardComponent>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
+  let router: Router;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -18,23 +19,29 @@ describe('TestCentreJournalCard', () => {
         CommonModule,
       ],
       providers: [
-        { provide: Router, useValue: routerSpy },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
       ],
     });
 
     fixture = TestBed.createComponent(TestCentreJournalCardComponent);
+    router = TestBed.inject(Router);
     component = fixture.componentInstance;
     fixture.detectChanges();
   }));
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(component)
+      .toBeTruthy();
   });
 
   describe('navigateToTestCentreJournal', () => {
-    it('should call router.navigate with correct info', () => {
-      component.navigateToTestCentreJournal();
-      expect(routerSpy.navigate).toHaveBeenCalledWith([TEST_CENTRE_JOURNAL_PAGE]);
+    it('should call router.navigate with correct info', async () => {
+      await component.navigateToTestCentreJournal();
+      expect(router.navigate)
+        .toHaveBeenCalledWith([TEST_CENTRE_JOURNAL_PAGE]);
     });
   });
 });

--- a/src/app/pages/dashboard/dashboard.page.ts
+++ b/src/app/pages/dashboard/dashboard.page.ts
@@ -1,18 +1,13 @@
 import { Component, Injector, OnInit } from '@angular/core';
-import { Store } from '@ngrx/store';
 import { ModalController, ViewDidEnter, ViewWillEnter } from '@ionic/angular';
 import { AppLauncher } from '@capacitor/app-launcher';
 
 import { combineLatest, from, merge, Observable, Subscription } from 'rxjs';
 import { filter, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
-import { KeepAwake as Insomnia } from '@capacitor-community/keep-awake';
-import { ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
 import { ExaminerRole, ExaminerRoleDescription } from '@providers/app-config/constants/examiner-role.constants';
 import { AppConfigProvider } from '@providers/app-config/app-config';
 import { DateTimeProvider } from '@providers/date-time/date-time';
 import { NetworkStateProvider } from '@providers/network-state/network-state';
-import { DeviceProvider } from '@providers/device/device';
-import { StoreModel } from '@shared/models/store.model';
 import { DateTime } from '@shared/helpers/date-time';
 import { BasePageComponent } from '@shared/classes/base-page';
 import {
@@ -63,9 +58,7 @@ interface DashboardPageState {
   templateUrl: 'dashboard.page.html',
   styleUrls: ['dashboard.page.scss'],
 })
-export class DashboardPage
-  extends BasePageComponent
-  implements OnInit, ViewDidEnter, ViewWillEnter {
+export class DashboardPage extends BasePageComponent implements OnInit, ViewDidEnter, ViewWillEnter {
 
   pageState: DashboardPageState;
   todaysDateFormatted: string;
@@ -77,10 +70,8 @@ export class DashboardPage
 
   constructor(
     private appConfigProvider: AppConfigProvider,
-    private store$: Store<StoreModel>,
     private dateTimeProvider: DateTimeProvider,
     private networkStateProvider: NetworkStateProvider,
-    public deviceProvider: DeviceProvider,
     private slotProvider: SlotProvider,
     private modalController: ModalController,
     injector: Injector,
@@ -139,11 +130,7 @@ export class DashboardPage
     this.store$.dispatch(StoreUnuploadedSlotsInTests());
     this.store$.dispatch(journalActions.LoadJournalSilent());
 
-    if (super.isIos()) {
-      await ScreenOrientation.unlock();
-      await Insomnia.allowSleep();
-      await this.deviceProvider.disableSingleAppMode();
-    }
+    await super.unlockDevice();
 
     if (this.merged$) {
       this.subscription = this.merged$.subscribe();

--- a/src/app/pages/delegated-rekey-search/delegated-rekey-search.ts
+++ b/src/app/pages/delegated-rekey-search/delegated-rekey-search.ts
@@ -1,9 +1,8 @@
 import { Component, Injector, OnInit } from '@angular/core';
 import { ModalController } from '@ionic/angular';
 import { BasePageComponent } from '@shared/classes/base-page';
-import { select, Store } from '@ngrx/store';
+import { select } from '@ngrx/store';
 import { getDelegatedRekeySearchState } from '@pages/delegated-rekey-search/delegated-rekey-search.reducer';
-import { StoreModel } from '@shared/models/store.model';
 import { distinctUntilChanged, map } from 'rxjs/operators';
 import { Observable, Subscription } from 'rxjs';
 import { TestSlot } from '@dvsa/mes-journal-schema';
@@ -13,13 +12,12 @@ import {
 } from '@pages/delegated-rekey-search/delegated-rekey-search-error-model';
 import { HttpErrorResponse } from '@angular/common/http';
 import {
-  getBookedTestSlot, getDelegatedRekeySearchError,
+  getBookedTestSlot,
+  getDelegatedRekeySearchError,
   getHasSearched,
   getIsLoading,
 } from '@pages/delegated-rekey-search/delegated-rekey-search.selector';
-import {
-  AbstractControl, UntypedFormControl, UntypedFormGroup, Validators,
-} from '@angular/forms';
+import { AbstractControl, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { ERROR_PAGE } from '@pages/page-names.constants';
 import { ErrorTypes } from '@shared/models/error-message';
 import { isEmpty } from 'lodash';
@@ -57,7 +55,6 @@ export class DelegatedRekeySearchPage extends BasePageComponent implements OnIni
 
   constructor(
     public orientationMonitorProvider: OrientationMonitorProvider,
-    private store$: Store<StoreModel>,
     private modalController: ModalController,
     private accessibilityService: AccessibilityService,
     injector: Injector,

--- a/src/app/pages/delegated-rekey-upload-outcome/delegated-rekey-upload-outcome.ts
+++ b/src/app/pages/delegated-rekey-upload-outcome/delegated-rekey-upload-outcome.ts
@@ -1,13 +1,11 @@
 import { Component, Injector, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { select, Store } from '@ngrx/store';
+import { select } from '@ngrx/store';
 import { ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
 import { KeepAwake as Insomnia } from '@capacitor-community/keep-awake';
 
-import { DeviceProvider } from '@providers/device/device';
 import { BasePageComponent } from '@shared/classes/base-page';
-import { StoreModel } from '@shared/models/store.model';
 import { SendCurrentTest } from '@store/tests/tests.actions';
 import { TestStatus } from '@store/tests/test-status/test-status.model';
 import { getTests } from '@store/tests/tests.reducer';
@@ -27,17 +25,11 @@ interface DelegatedRekeyUploadOutcomePageState {
   templateUrl: 'delegated-rekey-upload-outcome.html',
   styleUrls: ['delegated-rekey-upload-outcome.scss'],
 })
-export class DelegatedRekeyUploadOutcomePage
-  extends BasePageComponent
-  implements OnInit, ViewDidEnter {
+export class DelegatedRekeyUploadOutcomePage extends BasePageComponent implements OnInit, ViewDidEnter {
 
   pageState: DelegatedRekeyUploadOutcomePageState;
 
-  constructor(
-    private store$: Store<StoreModel>,
-    private deviceProvider: DeviceProvider,
-    injector: Injector,
-  ) {
+  constructor(injector: Injector) {
     super(injector);
   }
 

--- a/src/app/pages/error-page/__tests__/error.spec.ts
+++ b/src/app/pages/error-page/__tests__/error.spec.ts
@@ -1,20 +1,19 @@
-import {
-  ComponentFixture, waitForAsync, TestBed, fakeAsync,
-} from '@angular/core/testing';
-import {
-  NavParamsMock, AlertControllerMock,
-} from '@mocks/index.mock';
+import { ComponentFixture, fakeAsync, TestBed, waitForAsync } from '@angular/core/testing';
+import { ActivatedRouteMock, AlertControllerMock, NavParamsMock, RouterMock } from '@mocks/index.mock';
 import { MockComponent } from 'ng-mocks';
 import { By } from '@angular/platform-browser';
-import {
-  AlertController, IonicModule, ModalController, NavParams,
-} from '@ionic/angular';
-import { Router } from '@angular/router';
+import { AlertController, IonicModule, ModalController, NavParams } from '@ionic/angular';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { ErrorMessageComponent } from '@components/common/error-message/error-message';
 import { ModalControllerMock } from '@mocks/ionic-mocks/modal-controller.mock';
 import { ErrorPage } from '../error';
+import { DeviceProvider } from '@providers/device/device';
+import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
+import { LogHelper } from '@providers/logs/logs-helper';
+import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
+import { provideMockStore } from '@ngrx/store/testing';
 
 describe('ErrorPage', () => {
   let fixture: ComponentFixture<ErrorPage>;
@@ -30,11 +29,39 @@ describe('ErrorPage', () => {
         IonicModule,
       ],
       providers: [
-        { provide: Router, useFactory: () => {} },
-        { provide: NavParams, useClass: NavParamsMock },
-        { provide: ModalController, useClass: ModalControllerMock },
-        { provide: AlertController, useClass: AlertControllerMock },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: NavParams,
+          useClass: NavParamsMock,
+        },
+        {
+          provide: ModalController,
+          useClass: ModalControllerMock,
+        },
+        {
+          provide: AlertController,
+          useClass: AlertControllerMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: DeviceProvider,
+          useClass: DeviceProviderMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: ActivatedRouteMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
+        },
+        provideMockStore(),
       ],
     });
 
@@ -46,13 +73,16 @@ describe('ErrorPage', () => {
     it('should dismiss open modal', fakeAsync(async () => {
       spyOn(component.modalController, 'dismiss');
       await component.dismiss();
-      expect(component.modalController.dismiss).toHaveBeenCalled();
+      expect(component.modalController.dismiss)
+        .toHaveBeenCalled();
     }));
   });
 
   describe('DOM', () => {
     it('should display an error message', () => {
-      expect(fixture.debugElement.query(By.css('.error'))).not.toBeNull();
+      expect(fixture.debugElement.query(By.css('.error')))
+        .not
+        .toBeNull();
     });
   });
 });

--- a/src/app/pages/fake-journal/__tests__/fake-journal.page.spec.ts
+++ b/src/app/pages/fake-journal/__tests__/fake-journal.page.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule, Platform } from '@ionic/angular';
-import { PlatformMock } from '@mocks/index.mock';
-import { Router } from '@angular/router';
+import { ActivatedRouteMock, PlatformMock, RouterMock } from '@mocks/index.mock';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MockComponent } from 'ng-mocks';
 
 import { JournalNavigationComponent } from '@pages/journal/components/journal-navigation/journal-navigation';
@@ -18,12 +18,15 @@ import { OrientationMonitorProvider } from '@providers/orientation-monitor/orien
 import { DateTimeProvider } from '@providers/date-time/date-time';
 import { DateTimeProviderMock } from '@providers/date-time/__mocks__/date-time.mock';
 import { FakeJournalPage } from '../fake-journal.page';
+import { LogHelper } from '@providers/logs/logs-helper';
+import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
+import { DeviceProvider } from '@providers/device/device';
+import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
 
 describe('FakeJournalPage', () => {
   let component: FakeJournalPage;
   let fixture: ComponentFixture<FakeJournalPage>;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -53,7 +56,19 @@ describe('FakeJournalPage', () => {
         },
         {
           provide: Router,
-          useValue: routerSpy,
+          useClass: RouterMock,
+        },
+        {
+          provide: DeviceProvider,
+          useClass: DeviceProviderMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: ActivatedRouteMock,
         },
         provideMockStore({ initialState: {} }),
       ],

--- a/src/app/pages/fake-journal/fake-journal.page.ts
+++ b/src/app/pages/fake-journal/fake-journal.page.ts
@@ -2,8 +2,6 @@ import { Component, Injector } from '@angular/core';
 import { BasePageComponent } from '@shared/classes/base-page';
 import { fakeJournalTestSlots } from '@pages/fake-journal/__mocks__/fake-journal.mock';
 import * as moment from 'moment';
-import { StoreModel } from '@shared/models/store.model';
-import { Store } from '@ngrx/store';
 import { FakeJournalDidEnter } from '@pages/fake-journal/fake-journal.actions';
 import { OrientationMonitorProvider } from '@providers/orientation-monitor/orientation-monitor.provider';
 import { DateTimeProvider } from '@providers/date-time/date-time';
@@ -20,7 +18,6 @@ export class FakeJournalPage extends BasePageComponent {
   selectedDate: string;
 
   constructor(
-    private store$: Store<StoreModel>,
     private dateTimeProvider: DateTimeProvider,
     public orientationMonitorProvider: OrientationMonitorProvider,
     injector: Injector,

--- a/src/app/pages/health-declaration/__tests__/health-declaration.page.spec.ts
+++ b/src/app/pages/health-declaration/__tests__/health-declaration.page.spec.ts
@@ -1,12 +1,6 @@
-import {
-  ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync,
-} from '@angular/core/testing';
-import {
-  AlertController, NavController, NavParams, Platform,
-} from '@ionic/angular';
-import {
-  AlertControllerMock, NavControllerMock, NavParamsMock, PlatformMock,
-} from '@mocks/index.mock';
+import { ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { AlertController, NavController, NavParams, Platform } from '@ionic/angular';
+import { AlertControllerMock, NavControllerMock, NavParamsMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { AppModule } from '@app/app.module';
 import { HealthDeclarationPage } from '@pages/health-declaration/health-declaration.page';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
@@ -38,20 +32,17 @@ import { HealthDeclarationComponent } from '@pages/health-declaration/components
 import {
   ReceiptDeclarationComponent,
 } from '@pages/health-declaration/components/receipt-declaration/receipt-declaration';
-import {
-  ReactiveFormsModule, UntypedFormControl, UntypedFormGroup, Validators,
-} from '@angular/forms';
+import { ReactiveFormsModule, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { default as welshTranslations } from '@assets/i18n/cy.json';
-
-const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
 describe('HealthDeclarationPage', () => {
   let fixture: ComponentFixture<HealthDeclarationPage>;
   let component: HealthDeclarationPage;
   let store$: Store<StoreModel>;
   let translate: TranslateService;
+  let router: Router;
 
   const testSlotAttributes: TestSlotAttributes = {
     welshTest: false,
@@ -128,7 +119,7 @@ describe('HealthDeclarationPage', () => {
         },
         {
           provide: Router,
-          useValue: routerSpy,
+          useClass: RouterMock,
         },
       ],
     });
@@ -140,6 +131,7 @@ describe('HealthDeclarationPage', () => {
       .and
       .callThrough();
     translate = TestBed.inject(TranslateService);
+    router = TestBed.inject(Router);
     translate.setDefaultLang('en');
     component.subscription = new Subscription();
   }));
@@ -169,7 +161,7 @@ describe('HealthDeclarationPage', () => {
 
       describe('persistAndNavigate', () => {
         it('should dispatch a ProvisionalLicenseNotReceived if passed true and licenseProvided is true', async () => {
-          spyOn(routerSpy, 'navigate')
+          spyOn(router, 'navigate')
             .and
             .returnValue(Promise.resolve(true));
           component.licenseProvided = true;

--- a/src/app/pages/journal/journal.page.ts
+++ b/src/app/pages/journal/journal.page.ts
@@ -1,18 +1,16 @@
 import { Component, Injector, OnInit } from '@angular/core';
 import { IonRefresher, ModalController } from '@ionic/angular';
-import { select, Store } from '@ngrx/store';
+import { select } from '@ngrx/store';
 import { LoadingOptions } from '@ionic/core';
 import { merge, Observable, of, Subscription } from 'rxjs';
 import { map, switchMap, take } from 'rxjs/operators';
 import { SearchResultTestSchema } from '@dvsa/mes-search-schema';
 import { ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
-import { KeepAwake as Insomnia } from '@capacitor-community/keep-awake';
 
 import { SlotItem } from '@providers/slot-selector/slot-item';
 import { DateTimeProvider } from '@providers/date-time/date-time';
 import { NetworkStateProvider } from '@providers/network-state/network-state';
 import { BasePageComponent } from '@shared/classes/base-page';
-import { StoreModel } from '@shared/models/store.model';
 import { ErrorTypes } from '@shared/models/error-message';
 import { DateTime } from '@shared/helpers/date-time';
 import { MesError } from '@shared/models/mes-error.model';
@@ -29,7 +27,6 @@ import {
 } from '@store/journal/journal.selector';
 import { getJournalState } from '@store/journal/journal.reducer';
 import { selectVersionNumber } from '@store/app-info/app-info.selectors';
-import { DeviceProvider } from '@providers/device/device';
 import { LoadingProvider } from '@providers/loader/loader';
 import { OrientationMonitorProvider } from '@providers/orientation-monitor/orientation-monitor.provider';
 import { AccessibilityService } from '@providers/accessibility/accessibility.service';
@@ -71,11 +68,9 @@ export class JournalPage extends BasePageComponent implements OnInit {
   constructor(
     public modalController: ModalController,
     public orientationMonitorProvider: OrientationMonitorProvider,
-    private store$: Store<StoreModel>,
     public dateTimeProvider: DateTimeProvider,
     private accessibilityService: AccessibilityService,
     private networkStateProvider: NetworkStateProvider,
-    private deviceProvider: DeviceProvider,
     public loadingProvider: LoadingProvider,
     injector: Injector,
   ) {
@@ -172,12 +167,7 @@ export class JournalPage extends BasePageComponent implements OnInit {
 
   async ionViewDidEnter(): Promise<void> {
     this.store$.dispatch(journalActions.JournalViewDidEnter());
-
-    if (super.isIos()) {
-      await ScreenOrientation.unlock();
-      await Insomnia.allowSleep();
-      await this.deviceProvider.disableSingleAppMode();
-    }
+    await super.unlockDevice();
   }
 
   async loadJournalManually() {

--- a/src/app/pages/login/__tests__/login.page.spec.ts
+++ b/src/app/pages/login/__tests__/login.page.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, fakeAsync, flushMicrotasks, TestBed, waitForAsync } from '@angular/core/testing';
 import { AlertController, IonicModule, LoadingController, MenuController, Platform } from '@ionic/angular';
-import { Router } from '@angular/router';
+import { Navigation, NavigationExtras, Router } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
 import { SplashScreen } from '@capacitor/splash-screen';
 import { Capacitor } from '@capacitor/core';
@@ -20,7 +20,13 @@ import { DeviceProvider } from '@providers/device/device';
 import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
 import { Log, LogType } from '@shared/models/log.model';
 import { SaveLog, SendLogs } from '@store/logs/logs.actions';
-import { AlertControllerMock, LoadingControllerMock, MenuControllerMock, PlatformMock } from '@mocks/index.mock';
+import {
+  AlertControllerMock,
+  LoadingControllerMock,
+  MenuControllerMock,
+  PlatformMock,
+  RouterMock,
+} from '@mocks/index.mock';
 import { NetworkStateProvider } from '@providers/network-state/network-state';
 import { NetworkStateProviderMock } from '@providers/network-state/__mocks__/network-state.mock';
 import { DASHBOARD_PAGE } from '../../page-names.constants';
@@ -31,7 +37,6 @@ import { LoaderProviderMock } from '@providers/loader/__mocks__/loader.mock';
 describe('LoginPage', () => {
   let component: LoginPage;
   let fixture: ComponentFixture<LoginPage>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate', 'getCurrentNavigation']);
   let authenticationProvider: AuthenticationProvider;
   let appConfigProvider: AppConfigProvider;
   let platform: Platform;
@@ -41,6 +46,7 @@ describe('LoginPage', () => {
   let menuController: MenuController;
   let logHelper: LogHelper;
   let analytics: AnalyticsProvider;
+  let router: Router;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -68,7 +74,7 @@ describe('LoginPage', () => {
         },
         {
           provide: Router,
-          useValue: routerSpy,
+          useClass: RouterMock,
         },
         {
           provide: LoadingController,
@@ -123,6 +129,7 @@ describe('LoginPage', () => {
     menuController = TestBed.inject(MenuController);
     logHelper = TestBed.inject(LogHelper);
     analytics = TestBed.inject(AnalyticsProvider);
+    router = TestBed.inject(Router);
   }));
 
   it('should create', () => {
@@ -143,18 +150,18 @@ describe('LoginPage', () => {
         .returnValue(Promise.resolve());
     });
     it('should call login function when on ios', fakeAsync(() => {
-      spyOn(routerSpy, 'getCurrentNavigation')
+      spyOn(router, 'getCurrentNavigation')
         .and
-        .returnValue({ extras: { state: { hasLoggedOut: false } } });
+        .returnValue({ extras: { state: { hasLoggedOut: false } } as NavigationExtras } as Navigation);
       component.ngOnInit();
       flushMicrotasks();
       expect(component.login)
         .toHaveBeenCalled();
     }));
     it('should not run login on hasLoggedOut', fakeAsync(() => {
-      spyOn(routerSpy, 'getCurrentNavigation')
+      spyOn(router, 'getCurrentNavigation')
         .and
-        .returnValue({ extras: { state: { hasLoggedOut: true } } });
+        .returnValue({ extras: { state: { hasLoggedOut: true } } as NavigationExtras } as Navigation);
       component.ngOnInit();
       flushMicrotasks();
       expect(component.closeSideMenuIfOpen)
@@ -425,14 +432,14 @@ describe('LoginPage', () => {
   });
   describe('validateDeviceType', () => {
     beforeEach(() => {
-      spyOn(routerSpy, 'navigate');
+      spyOn(router, 'navigate');
     });
     it('should navigate to dashboard page', async () => {
       spyOn(component.deviceProvider, 'validDeviceType')
         .and
         .returnValue(Promise.resolve(true));
       await component.validateDeviceType();
-      expect(routerSpy.navigate)
+      expect(router.navigate)
         .toHaveBeenCalledWith([DASHBOARD_PAGE], { replaceUrl: true });
     });
   });

--- a/src/app/pages/non-pass-finalisation/non-pass-finalisation.page.ts
+++ b/src/app/pages/non-pass-finalisation/non-pass-finalisation.page.ts
@@ -127,13 +127,13 @@ export class NonPassFinalisationPage extends PracticeableBasePageComponent imple
     private outcomeBehaviourProvider: OutcomeBehaviourMapProvider,
     public activityCodeFinalisationProvider: ActivityCodeFinalisationProvider,
     public modalController: ModalController,
-    private route: ActivatedRoute,
+    private activatedRoute: ActivatedRoute,
     private testDataByCategoryProvider: TestDataByCategoryProvider,
     injector: Injector,
   ) {
     super(injector, false);
     this.form = new UntypedFormGroup({});
-    const { nonPassData } = this.route.snapshot.data;
+    const { nonPassData } = this.activatedRoute.snapshot.data;
     const [behaviourMap, activityCodeList] = nonPassData;
     this.activityCodeOptions = activityCodeList;
     this.outcomeBehaviourProvider.setBehaviourMap(behaviourMap);

--- a/src/app/pages/pass-finalisation/cat-a-mod1/__tests__/pass-finalisation.cat-a-mod1.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-a-mod1/__tests__/pass-finalisation.cat-a-mod1.page.spec.ts
@@ -1,10 +1,5 @@
-import {
-  ComponentFixture, TestBed, waitForAsync, fakeAsync, tick,
-} from '@angular/core/testing';
-import {
-  NavControllerMock,
-  PlatformMock,
-} from '@mocks/index.mock';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { Store } from '@ngrx/store';
@@ -17,15 +12,11 @@ import { FinalisationHeaderComponent } from '@components/test-finalisation/final
 import { LanguagePreferencesComponent } from '@components/test-finalisation/language-preference/language-preference';
 import { DebriefWitnessedComponent } from '@components/test-finalisation/debrief-witnessed/debrief-witnessed';
 import { PracticeModeBanner } from '@components/common/practice-mode-banner/practice-mode-banner';
-import {
-  LicenseProvidedComponent,
-} from '@pages/pass-finalisation/components/license-provided/license-provided';
+import { LicenseProvidedComponent } from '@pages/pass-finalisation/components/license-provided/license-provided';
 import {
   LicenceProvidedWarningBannerComponent,
 } from '@pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner';
-import {
-  NavController, Platform,
-} from '@ionic/angular';
+import { NavController, Platform } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { D255Component } from '@components/test-finalisation/d255/d255';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
@@ -33,7 +24,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/outcome-behaviour-map';
 import { PersistTests } from '@store/tests/tests.actions';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import {
   PassFinalisationValidationError,
   PassFinalisationViewDidEnter,
@@ -51,7 +42,6 @@ describe('PassFinalisationCatAMod1Page', () => {
   let fixture: ComponentFixture<PassFinalisationCatAMod1Page>;
   let component: PassFinalisationCatAMod1Page;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -75,10 +65,22 @@ describe('PassFinalisationCatAMod1Page', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         OutcomeBehaviourMapProvider,
       ],
     });
@@ -96,7 +98,8 @@ describe('PassFinalisationCatAMod1Page', () => {
         component.subscription = new Subscription();
         spyOn(component.subscription, 'unsubscribe');
         component.ionViewDidLeave();
-        expect(component.subscription.unsubscribe).toHaveBeenCalled();
+        expect(component.subscription.unsubscribe)
+          .toHaveBeenCalled();
       });
     });
 
@@ -106,7 +109,8 @@ describe('PassFinalisationCatAMod1Page', () => {
         component.subscription.closed = true;
         spyOn(store$, 'dispatch');
         component.ionViewWillEnter();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationViewDidEnter());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationViewDidEnter());
       });
     });
 
@@ -115,32 +119,37 @@ describe('PassFinalisationCatAMod1Page', () => {
         component.transmission = 'Automatic';
         component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl() });
         component.form.controls['transmissionCtrl'].markAsDirty();
-        expect(component.displayTransmissionBanner()).toEqual(true);
+        expect(component.displayTransmissionBanner())
+          .toEqual(true);
       });
       it('should return false if transmission is not automatic and form is dirty', () => {
         component.transmission = 'Manual';
         component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl() });
         component.form.controls['transmissionCtrl'].markAsDirty();
-        expect(component.displayTransmissionBanner()).toEqual(false);
+        expect(component.displayTransmissionBanner())
+          .toEqual(false);
       });
       it('should return false if transmission is automatic and form is not dirty', () => {
         component.transmission = 'Automatic';
         component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl() });
         component.form.controls['transmissionCtrl'].markAsPristine();
-        expect(component.displayTransmissionBanner()).toEqual(false);
+        expect(component.displayTransmissionBanner())
+          .toEqual(false);
       });
       it('should return false if transmission is not automatic and form is not dirty', () => {
         component.transmission = 'Manual';
         component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl() });
         component.form.controls['transmissionCtrl'].markAsPristine();
-        expect(component.displayTransmissionBanner()).toEqual(false);
+        expect(component.displayTransmissionBanner())
+          .toEqual(false);
       });
     });
 
     describe('onSubmit', () => {
       it('should dispatch the PersistTests action', () => {
         component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(PersistTests());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PersistTests());
       });
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
         component.form = new UntypedFormGroup({
@@ -152,8 +161,10 @@ describe('PassFinalisationCatAMod1Page', () => {
 
         component.onSubmit();
         tick();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
         expect(store$.dispatch)
           .toHaveBeenCalledWith(PassFinalisationValidationError(`${PASS_CERTIFICATE_NUMBER_CTRL} is invalid`));
         expect(store$.dispatch)

--- a/src/app/pages/pass-finalisation/cat-a-mod2/__tests__/pass-finalisation.cat-a-mod2.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-a-mod2/__tests__/pass-finalisation.cat-a-mod2.page.spec.ts
@@ -1,6 +1,4 @@
-import {
-  waitForAsync, ComponentFixture, TestBed, fakeAsync, tick,
-} from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { NavController, Platform } from '@ionic/angular';
 
 import { Store } from '@ngrx/store';
@@ -24,7 +22,7 @@ import {
 } from '@pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppModule } from '@app/app.module';
-import { NavControllerMock, PlatformMock } from '@mocks/index.mock';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { Router } from '@angular/router';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
@@ -49,7 +47,6 @@ describe('PassFinalisationCatAMod2Page', () => {
   let fixture: ComponentFixture<PassFinalisationCatAMod2Page>;
   let component: PassFinalisationCatAMod2Page;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -73,10 +70,22 @@ describe('PassFinalisationCatAMod2Page', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         OutcomeBehaviourMapProvider,
       ],
     });
@@ -93,8 +102,10 @@ describe('PassFinalisationCatAMod2Page', () => {
       it('should dispatch the VIEW_DID_ENTER action when the function is run', () => {
         spyOn(PassFinalisationPageComponent.prototype, 'ionViewWillEnter');
         component.ionViewWillEnter();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationViewDidEnter());
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationViewDidEnter());
+        expect(store$.dispatch)
+          .toHaveBeenCalledTimes(1);
       });
     });
 
@@ -102,7 +113,8 @@ describe('PassFinalisationCatAMod2Page', () => {
       // Unit tests for the components TypeScript class
       it('should dispatch the PersistTests action', () => {
         component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(PersistTests());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PersistTests());
       });
 
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
@@ -132,7 +144,8 @@ describe('PassFinalisationCatAMod2Page', () => {
         component.subscription = new Subscription();
         spyOn(component.subscription, 'unsubscribe');
         component.ionViewDidLeave();
-        expect(component.subscription.unsubscribe).toHaveBeenCalled();
+        expect(component.subscription.unsubscribe)
+          .toHaveBeenCalled();
       });
     });
 
@@ -143,7 +156,8 @@ describe('PassFinalisationCatAMod2Page', () => {
         component.form.controls['transmissionCtrl'].markAsPristine();
         component.transmission = TransmissionType.Automatic;
 
-        expect(component.displayTransmissionBanner()).toEqual(false);
+        expect(component.displayTransmissionBanner())
+          .toEqual(false);
       });
       it('return false if transmissionCtrl is dirty and transmission is manual', () => {
         component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl(null) });
@@ -151,7 +165,8 @@ describe('PassFinalisationCatAMod2Page', () => {
         component.form.controls['transmissionCtrl'].markAsDirty();
         component.transmission = TransmissionType.Manual;
 
-        expect(component.displayTransmissionBanner()).toEqual(false);
+        expect(component.displayTransmissionBanner())
+          .toEqual(false);
       });
       it('return true if transmissionCtrl is dirty and transmission is automatic', () => {
         component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl(null) });
@@ -159,7 +174,8 @@ describe('PassFinalisationCatAMod2Page', () => {
         component.form.controls['transmissionCtrl'].markAsDirty();
         component.transmission = TransmissionType.Automatic;
 
-        expect(component.displayTransmissionBanner()).toEqual(true);
+        expect(component.displayTransmissionBanner())
+          .toEqual(true);
       });
     });
 

--- a/src/app/pages/pass-finalisation/cat-adi-part2/__tests__/pass-finalisation.cat-adi-part2.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-adi-part2/__tests__/pass-finalisation.cat-adi-part2.page.spec.ts
@@ -1,7 +1,5 @@
-import {
-  ComponentFixture, TestBed, waitForAsync, fakeAsync, tick,
-} from '@angular/core/testing';
-import { NavControllerMock, PlatformMock } from '@mocks/index.mock';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { Store } from '@ngrx/store';
@@ -14,15 +12,11 @@ import { FinalisationHeaderComponent } from '@components/test-finalisation/final
 import { LanguagePreferencesComponent } from '@components/test-finalisation/language-preference/language-preference';
 import { DebriefWitnessedComponent } from '@components/test-finalisation/debrief-witnessed/debrief-witnessed';
 import { PracticeModeBanner } from '@components/common/practice-mode-banner/practice-mode-banner';
-import {
-  LicenseProvidedComponent,
-} from '@pages/pass-finalisation/components/license-provided/license-provided';
+import { LicenseProvidedComponent } from '@pages/pass-finalisation/components/license-provided/license-provided';
 import {
   LicenceProvidedWarningBannerComponent,
 } from '@pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner';
-import {
-  NavController, Platform,
-} from '@ionic/angular';
+import { NavController, Platform } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { D255Component } from '@components/test-finalisation/d255/d255';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
@@ -30,7 +24,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/outcome-behaviour-map';
 import { PersistTests } from '@store/tests/tests.actions';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import {
   PassFinalisationValidationError,
   PassFinalisationViewDidEnter,
@@ -44,7 +38,6 @@ describe('PassFinalisationCatADI2Page', () => {
   let fixture: ComponentFixture<PassFinalisationCatADI2Page>;
   let component: PassFinalisationCatADI2Page;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -66,10 +59,22 @@ describe('PassFinalisationCatADI2Page', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         OutcomeBehaviourMapProvider,
       ],
     });
@@ -85,7 +90,8 @@ describe('PassFinalisationCatADI2Page', () => {
     describe('onSubmit', () => {
       it('should dispatch the PersistTests action', () => {
         component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(PersistTests());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PersistTests());
       });
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
         component.form = new UntypedFormGroup({
@@ -97,8 +103,10 @@ describe('PassFinalisationCatADI2Page', () => {
 
         component.onSubmit();
         tick();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
         expect(store$.dispatch)
           .not
           .toHaveBeenCalledWith(PassFinalisationValidationError('notRequiredControl is blank'));
@@ -107,7 +115,8 @@ describe('PassFinalisationCatADI2Page', () => {
     describe('ionViewWillEnter', () => {
       it('should dispatch with PassFinalisationViewDidEnter', () => {
         component.ionViewWillEnter();
-        expect(component.store$.dispatch).toHaveBeenCalledWith(PassFinalisationViewDidEnter());
+        expect(component.store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationViewDidEnter());
       });
     });
   });

--- a/src/app/pages/pass-finalisation/cat-adi-part3/__tests__/pass-finalisation.cat-adi-part3.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-adi-part3/__tests__/pass-finalisation.cat-adi-part3.page.spec.ts
@@ -1,10 +1,6 @@
-import {
-  ComponentFixture, TestBed, waitForAsync,
-} from '@angular/core/testing';
-import {
-  NavController, Platform,
-} from '@ionic/angular';
-import { NavControllerMock, PlatformMock } from '@mocks/index.mock';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { NavController, Platform } from '@ionic/angular';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { Router } from '@angular/router';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
@@ -43,7 +39,6 @@ describe('PassFinalisationCatADIPart3Page', () => {
   let component: PassFinalisationCatADIPart3Page;
   let fixture: ComponentFixture<PassFinalisationCatADIPart3Page>;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   const initialState = {
     appInfo: { employeeId: '123456' },
@@ -57,7 +52,10 @@ describe('PassFinalisationCatADIPart3Page', () => {
           version: '1',
           rekey: false,
           activityCode: '1',
-          passCompletion: { passCertificateNumber: 'test', code78Present: true },
+          passCompletion: {
+            passCertificateNumber: 'test',
+            code78Present: true,
+          },
           category: TestCategory.SC,
           changeMarker: null,
           examinerBooked: null,
@@ -124,11 +122,23 @@ describe('PassFinalisationCatADIPart3Page', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: Router, useValue: routerSpy },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
         { provide: Store },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         OutcomeBehaviourMapProvider,
         provideMockStore({ initialState }),
       ],
@@ -142,13 +152,15 @@ describe('PassFinalisationCatADIPart3Page', () => {
 
   describe('class', () => {
     it('should create', () => {
-      expect(component).toBeTruthy();
+      expect(component)
+        .toBeTruthy();
     });
 
     describe('furtherDevelopmentChanged', () => {
       it('should dispatch SeekFurtherDevelopmentChanged using the parameter given', () => {
         component.furtherDevelopmentChanged(true);
-        expect(store$.dispatch).toHaveBeenCalledWith(SeekFurtherDevelopmentChanged(true));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(SeekFurtherDevelopmentChanged(true));
       });
     });
 
@@ -156,11 +168,14 @@ describe('PassFinalisationCatADIPart3Page', () => {
       it('should resolve state variables', () => {
         component.ngOnInit();
         component.pageState.isStandardsCheck$
-          .subscribe((res) => expect(res).toEqual(true));
+          .subscribe((res) => expect(res)
+            .toEqual(true));
         component.pageState.testStartTime$
-          .subscribe((res) => expect(res).toEqual('1111-01-01T01:01:01'));
+          .subscribe((res) => expect(res)
+            .toEqual('1111-01-01T01:01:01'));
         component.pageState.testEndTime$
-          .subscribe((res) => expect(res).toEqual('4444-04-04T04:44:44'));
+          .subscribe((res) => expect(res)
+            .toEqual('4444-04-04T04:44:44'));
       });
     });
 
@@ -178,7 +193,8 @@ describe('PassFinalisationCatADIPart3Page', () => {
       it('should dispatch endTime to store', () => {
         spyOn(store$, 'dispatch');
         component.testStartTimeChanged('test');
-        expect(store$.dispatch).toHaveBeenCalledWith(StartTimeChanged('test'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(StartTimeChanged('test'));
       });
     });
 
@@ -186,7 +202,8 @@ describe('PassFinalisationCatADIPart3Page', () => {
       it('should dispatch endTime to store', () => {
         spyOn(store$, 'dispatch');
         component.testEndTimeChanged('test');
-        expect(store$.dispatch).toHaveBeenCalledWith(EndTimeChanged('test'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(EndTimeChanged('test'));
       });
     });
 
@@ -194,14 +211,16 @@ describe('PassFinalisationCatADIPart3Page', () => {
       it('should dispatch PassFinalisationViewDidEnter', () => {
         spyOn(store$, 'dispatch');
         component.ionViewWillEnter();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationViewDidEnter());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationViewDidEnter());
       });
     });
 
     describe('adviceReasonChanged', () => {
       it('should dispatch ReasonForNoAdviceGivenChanged using the parameter given ', () => {
         component.adviceReasonChanged('test');
-        expect(store$.dispatch).toHaveBeenCalledWith(ReasonForNoAdviceGivenChanged('test'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(ReasonForNoAdviceGivenChanged('test'));
       });
     });
 
@@ -212,7 +231,8 @@ describe('PassFinalisationCatADIPart3Page', () => {
         spyOn(component, 'adviceReasonChanged');
         component.onSubmit();
 
-        expect(component.adviceReasonChanged).toHaveBeenCalledWith(null);
+        expect(component.adviceReasonChanged)
+          .toHaveBeenCalledWith(null);
       });
       it('should dispatch PassFinalisationValidationError if the controls are invalid', () => {
         component.form = new UntypedFormGroup({});
@@ -223,9 +243,11 @@ describe('PassFinalisationCatADIPart3Page', () => {
         }
         component.onSubmit();
 
-        Object.keys(component.form.controls).forEach((controlName) => {
-          expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError(`${controlName} is blank`));
-        });
+        Object.keys(component.form.controls)
+          .forEach((controlName) => {
+            expect(store$.dispatch)
+              .toHaveBeenCalledWith(PassFinalisationValidationError(`${controlName} is blank`));
+          });
       });
     });
   });

--- a/src/app/pages/pass-finalisation/cat-b/__tests__/pass-finalisation.cat-b.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-b/__tests__/pass-finalisation.cat-b.page.spec.ts
@@ -1,16 +1,11 @@
-import {
-  ComponentFixture, TestBed, fakeAsync, tick, waitForAsync,
-} from '@angular/core/testing';
-import {
-  NavControllerMock,
-  PlatformMock,
-} from '@mocks/index.mock';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { Store } from '@ngrx/store';
 import { StoreModel } from '@shared/models/store.model';
 import { MockComponent } from 'ng-mocks';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import { WarningBannerComponent } from '@components/common/warning-banner/warning-banner';
 import { TransmissionComponent } from '@components/common/transmission/transmission';
@@ -18,19 +13,19 @@ import { FinalisationHeaderComponent } from '@components/test-finalisation/final
 import { LanguagePreferencesComponent } from '@components/test-finalisation/language-preference/language-preference';
 import { DebriefWitnessedComponent } from '@components/test-finalisation/debrief-witnessed/debrief-witnessed';
 import { PracticeModeBanner } from '@components/common/practice-mode-banner/practice-mode-banner';
-import { PassCertificateNumberComponent }
-  from '@pages/pass-finalisation/components/pass-certificate-number/pass-certificate-number';
-import { LicenseProvidedComponent }
-  from '@pages/pass-finalisation/components/license-provided/license-provided';
-import { LicenceProvidedWarningBannerComponent }
-  from '@pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner';
 import {
-  NavController, Platform,
-} from '@ionic/angular';
+  PassCertificateNumberComponent,
+} from '@pages/pass-finalisation/components/pass-certificate-number/pass-certificate-number';
+import { LicenseProvidedComponent } from '@pages/pass-finalisation/components/license-provided/license-provided';
+import {
+  LicenceProvidedWarningBannerComponent,
+} from '@pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner';
+import { NavController, Platform } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { PersistTests } from '@store/tests/tests.actions';
-import { PASS_CERTIFICATE_NUMBER_CTRL }
-  from '@pages/pass-finalisation/components/pass-certificate-number/pass-certificate-number.constants';
+import {
+  PASS_CERTIFICATE_NUMBER_CTRL,
+} from '@pages/pass-finalisation/components/pass-certificate-number/pass-certificate-number.constants';
 import { D255Component } from '@components/test-finalisation/d255/d255';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { Router } from '@angular/router';
@@ -42,16 +37,12 @@ import { TestResultCommonSchema } from '@dvsa/mes-test-schema/categories/common'
 import { TestsModel } from '@store/tests/tests.model';
 import { provideMockStore } from '@ngrx/store/testing';
 import { PassFinalisationCatBPage } from '../pass-finalisation.cat-b.page';
-import {
-  PassFinalisationViewDidEnter,
-  PassFinalisationValidationError,
-} from '../../pass-finalisation.actions';
+import { PassFinalisationValidationError, PassFinalisationViewDidEnter } from '../../pass-finalisation.actions';
 
 describe('PassFinalisationCatBPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatBPage>;
   let component: PassFinalisationCatBPage;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   const initialState = {
     appInfo: { employeeId: '123456' },
@@ -65,7 +56,10 @@ describe('PassFinalisationCatBPage', () => {
           version: '1',
           rekey: false,
           activityCode: '1',
-          passCompletion: { passCertificateNumber: 'test', code78: true },
+          passCompletion: {
+            passCertificateNumber: 'test',
+            code78: true,
+          },
           category: TestCategory.D,
           changeMarker: null,
           examinerBooked: null,
@@ -146,10 +140,22 @@ describe('PassFinalisationCatBPage', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         provideMockStore({ initialState }),
         OutcomeBehaviourMapProvider,
       ],
@@ -175,27 +181,32 @@ describe('PassFinalisationCatBPage', () => {
         component.ngOnInit();
         component.pageState.transmissionManualRadioChecked$.subscribe();
 
-        expect(component.form.controls['transmissionCtrl'].value).toEqual('Manual');
+        expect(component.form.controls['transmissionCtrl'].value)
+          .toEqual('Manual');
       });
     });
 
     describe('ionViewDidEnter', () => {
       it('should dispatch the VIEW_DID_ENTER action when the function is run', () => {
         component.ionViewDidEnter();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationViewDidEnter());
-        expect(store$.dispatch).toHaveBeenCalledTimes(1);
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationViewDidEnter());
+        expect(store$.dispatch)
+          .toHaveBeenCalledTimes(1);
       });
     });
     describe('onSubmit', () => {
       it('should dispatch the ProvisionalLicenseNotReceived action', async () => {
         component.candidateDriverNumber = '1234567';
         await component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(ProvisionalLicenseNotReceived());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(ProvisionalLicenseNotReceived());
       });
       // Unit tests for the components TypeScript class
       it('should dispatch the PersistTests action', async () => {
         await component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(PersistTests());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PersistTests());
       });
 
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
@@ -223,13 +234,15 @@ describe('PassFinalisationCatBPage', () => {
   });
 
   describe('isNorthernIreland', () => {
-    const UKlicence : string = 'JONES849339TS8AD';
-    const NIlicence : string = '23514780';
+    const UKlicence: string = 'JONES849339TS8AD';
+    const NIlicence: string = '23514780';
     it('should return true if driving licence is Northern Ireland', () => {
-      expect(component.isNorthernIreland(NIlicence)).toEqual(true);
+      expect(component.isNorthernIreland(NIlicence))
+        .toEqual(true);
     });
     it('should return false if driving licence is Northern Ireland', () => {
-      expect(component.isNorthernIreland(UKlicence)).toEqual(false);
+      expect(component.isNorthernIreland(UKlicence))
+        .toEqual(false);
     });
   });
 
@@ -238,7 +251,8 @@ describe('PassFinalisationCatBPage', () => {
       component.subscription = new Subscription();
       spyOn(component.subscription, 'unsubscribe');
       component.ionViewDidLeave();
-      expect(component.subscription.unsubscribe).toHaveBeenCalled();
+      expect(component.subscription.unsubscribe)
+        .toHaveBeenCalled();
     });
   });
 
@@ -247,25 +261,29 @@ describe('PassFinalisationCatBPage', () => {
       component.transmission = 'Automatic';
       component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl() });
       component.form.controls['transmissionCtrl'].markAsDirty();
-      expect(component.displayTransmissionBanner()).toEqual(true);
+      expect(component.displayTransmissionBanner())
+        .toEqual(true);
     });
     it('should return false if transmission is not automatic and form is dirty', () => {
       component.transmission = 'Manual';
       component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl() });
       component.form.controls['transmissionCtrl'].markAsDirty();
-      expect(component.displayTransmissionBanner()).toEqual(false);
+      expect(component.displayTransmissionBanner())
+        .toEqual(false);
     });
     it('should return false if transmission is automatic and form is not dirty', () => {
       component.transmission = 'Automatic';
       component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl() });
       component.form.controls['transmissionCtrl'].markAsPristine();
-      expect(component.displayTransmissionBanner()).toEqual(false);
+      expect(component.displayTransmissionBanner())
+        .toEqual(false);
     });
     it('should return false if transmission is not automatic and form is not dirty', () => {
       component.transmission = 'Manual';
       component.form = new UntypedFormGroup({ transmissionCtrl: new UntypedFormControl() });
       component.form.controls['transmissionCtrl'].markAsPristine();
-      expect(component.displayTransmissionBanner()).toEqual(false);
+      expect(component.displayTransmissionBanner())
+        .toEqual(false);
     });
   });
 

--- a/src/app/pages/pass-finalisation/cat-c/__tests__/pass-finalisation.cat-c.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-c/__tests__/pass-finalisation.cat-c.page.spec.ts
@@ -1,10 +1,5 @@
-import {
-  ComponentFixture, TestBed, waitForAsync, fakeAsync, tick,
-} from '@angular/core/testing';
-import {
-  NavControllerMock,
-  PlatformMock,
-} from '@mocks/index.mock';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { Store } from '@ngrx/store';
@@ -20,15 +15,11 @@ import { PracticeModeBanner } from '@components/common/practice-mode-banner/prac
 import {
   PassCertificateNumberComponent,
 } from '@pages/pass-finalisation/components/pass-certificate-number/pass-certificate-number';
-import {
-  LicenseProvidedComponent,
-} from '@pages/pass-finalisation/components/license-provided/license-provided';
+import { LicenseProvidedComponent } from '@pages/pass-finalisation/components/license-provided/license-provided';
 import {
   LicenceProvidedWarningBannerComponent,
 } from '@pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner';
-import {
-  NavController, Platform,
-} from '@ionic/angular';
+import { NavController, Platform } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { D255Component } from '@components/test-finalisation/d255/d255';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
@@ -38,7 +29,7 @@ import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/ou
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { TransmissionType } from '@shared/models/transmission-type';
 import { PersistTests } from '@store/tests/tests.actions';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import {
   PassFinalisationValidationError,
   PassFinalisationViewDidEnter,
@@ -56,7 +47,6 @@ describe('PassFinalisationCatCPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatCPage>;
   let component: PassFinalisationCatCPage;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   const initialState = {
     appInfo: { employeeId: '123456' },
@@ -70,7 +60,10 @@ describe('PassFinalisationCatCPage', () => {
           version: '1',
           rekey: false,
           activityCode: '1',
-          passCompletion: { passCertificateNumber: 'test', code78Present: true },
+          passCompletion: {
+            passCertificateNumber: 'test',
+            code78Present: true,
+          },
           category: TestCategory.D,
           changeMarker: null,
           examinerBooked: null,
@@ -281,10 +274,22 @@ describe('PassFinalisationCatCPage', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         provideMockStore({ initialState }),
         OutcomeBehaviourMapProvider,
       ],
@@ -304,13 +309,15 @@ describe('PassFinalisationCatCPage', () => {
         component.subscription = new Subscription();
         spyOn(component.subscription, 'unsubscribe');
         component.ionViewDidLeave();
-        expect(component.subscription.unsubscribe).toHaveBeenCalled();
+        expect(component.subscription.unsubscribe)
+          .toHaveBeenCalled();
       });
     });
     describe('shouldShowCandidateDoesntNeedLicenseBanner', () => {
       it('return provisionalLicenseIsReceived', () => {
         component.provisionalLicenseIsReceived = true;
-        expect(component.shouldShowCandidateDoesntNeedLicenseBanner()).toEqual(true);
+        expect(component.shouldShowCandidateDoesntNeedLicenseBanner())
+          .toEqual(true);
       });
     });
 
@@ -329,14 +336,16 @@ describe('PassFinalisationCatCPage', () => {
       it('should dispatch PassFinalisationViewDidEnter', () => {
         spyOn(store$, 'dispatch');
         component.ionViewWillEnter();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationViewDidEnter());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationViewDidEnter());
       });
     });
 
     describe('onSubmit', () => {
       it('should dispatch the PersistTests action', () => {
         component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(PersistTests());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PersistTests());
       });
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
         component.form = new UntypedFormGroup({
@@ -348,8 +357,10 @@ describe('PassFinalisationCatCPage', () => {
 
         component.onSubmit();
         tick();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
         expect(store$.dispatch)
           .toHaveBeenCalledWith(PassFinalisationValidationError(`${PASS_CERTIFICATE_NUMBER_CTRL} is invalid`));
         expect(store$.dispatch)
@@ -363,15 +374,18 @@ describe('PassFinalisationCatCPage', () => {
           component.transmission = cat.transmission;
           component.code78Present = cat.code78;
           component.testCategory = cat.category;
-          expect(component.shouldShowAutomaticBanner()).toEqual(cat.automaticBanner);
-          expect(component.shouldShowManualBanner()).toEqual(cat.manualBanner);
+          expect(component.shouldShowAutomaticBanner())
+            .toEqual(cat.automaticBanner);
+          expect(component.shouldShowManualBanner())
+            .toEqual(cat.manualBanner);
         });
       });
     });
     describe('shouldHideBanner', () => {
       it('should hide banner when only transmission is selected', () => {
         component.transmission = TransmissionType.Manual;
-        expect(component.shouldShowCode78Banner()).toEqual(false);
+        expect(component.shouldShowCode78Banner())
+          .toEqual(false);
       });
     });
   });

--- a/src/app/pages/pass-finalisation/cat-cpc/__tests__/pass-finalisation.cat-cpc.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-cpc/__tests__/pass-finalisation.cat-cpc.page.spec.ts
@@ -1,10 +1,5 @@
-import {
-  ComponentFixture, TestBed, waitForAsync, fakeAsync, tick,
-} from '@angular/core/testing';
-import {
-  NavControllerMock,
-  PlatformMock,
-} from '@mocks/index.mock';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { Store } from '@ngrx/store';
@@ -19,16 +14,14 @@ import { PracticeModeBanner } from '@components/common/practice-mode-banner/prac
 import {
   PassCertificateNumberComponent,
 } from '@pages/pass-finalisation/components/pass-certificate-number/pass-certificate-number';
-import {
-  NavController, Platform,
-} from '@ionic/angular';
+import { NavController, Platform } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/outcome-behaviour-map';
 import { PersistTests } from '@store/tests/tests.actions';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { PassFinalisationValidationError } from '@pages/pass-finalisation/pass-finalisation.actions';
 import {
   PASS_CERTIFICATE_NUMBER_CTRL,
@@ -39,7 +32,6 @@ describe('PassFinalisationCatCPCPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatCPCPage>;
   let component: PassFinalisationCatCPCPage;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -58,10 +50,22 @@ describe('PassFinalisationCatCPCPage', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         OutcomeBehaviourMapProvider,
       ],
     });
@@ -79,7 +83,8 @@ describe('PassFinalisationCatCPCPage', () => {
         component.subscription = new Subscription();
         spyOn(component.subscription, 'unsubscribe');
         component.ionViewDidLeave();
-        expect(component.subscription.unsubscribe).toHaveBeenCalled();
+        expect(component.subscription.unsubscribe)
+          .toHaveBeenCalled();
       });
     });
     describe('ionViewWillEnter', () => {
@@ -87,13 +92,15 @@ describe('PassFinalisationCatCPCPage', () => {
         component.merged$ = new Observable<string | boolean>();
         component.ionViewWillEnter();
 
-        expect(component.subscription).toBeDefined();
+        expect(component.subscription)
+          .toBeDefined();
       });
     });
     describe('onSubmit', () => {
       it('should dispatch the PersistTests action', () => {
         component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(PersistTests());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PersistTests());
       });
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
         component.form = new UntypedFormGroup({
@@ -105,8 +112,10 @@ describe('PassFinalisationCatCPCPage', () => {
 
         component.onSubmit();
         tick();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
         expect(store$.dispatch)
           .toHaveBeenCalledWith(PassFinalisationValidationError(`${PASS_CERTIFICATE_NUMBER_CTRL} is invalid`));
         expect(store$.dispatch)

--- a/src/app/pages/pass-finalisation/cat-d/__tests__/pass-finalisation.cat-d.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-d/__tests__/pass-finalisation.cat-d.page.spec.ts
@@ -1,8 +1,6 @@
-import {
-  ComponentFixture, TestBed, waitForAsync, fakeAsync, tick,
-} from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { NavController, Platform } from '@ionic/angular';
-import { NavControllerMock, PlatformMock } from '@mocks/index.mock';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { Store } from '@ngrx/store';
@@ -18,9 +16,7 @@ import { PracticeModeBanner } from '@components/common/practice-mode-banner/prac
 import {
   PassCertificateNumberComponent,
 } from '@pages/pass-finalisation/components/pass-certificate-number/pass-certificate-number';
-import {
-  LicenseProvidedComponent,
-} from '@pages/pass-finalisation/components/license-provided/license-provided';
+import { LicenseProvidedComponent } from '@pages/pass-finalisation/components/license-provided/license-provided';
 import {
   LicenceProvidedWarningBannerComponent,
 } from '@pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner';
@@ -33,7 +29,7 @@ import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/ou
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { TransmissionType } from '@shared/models/transmission-type';
 import { PersistTests } from '@store/tests/tests.actions';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { PassFinalisationValidationError } from '@pages/pass-finalisation/pass-finalisation.actions';
 import {
   PASS_CERTIFICATE_NUMBER_CTRL,
@@ -48,7 +44,6 @@ describe('PassFinalisationCatDPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatDPage>;
   let component: PassFinalisationCatDPage;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   const initialState = {
     appInfo: { employeeId: '123456' },
@@ -62,7 +57,10 @@ describe('PassFinalisationCatDPage', () => {
           version: '1',
           rekey: false,
           activityCode: '1',
-          passCompletion: { passCertificateNumber: 'test', code78Present: true },
+          passCompletion: {
+            passCertificateNumber: 'test',
+            code78Present: true,
+          },
           category: TestCategory.D,
           changeMarker: null,
           examinerBooked: null,
@@ -273,10 +271,22 @@ describe('PassFinalisationCatDPage', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         provideMockStore({ initialState }),
         OutcomeBehaviourMapProvider,
       ],
@@ -293,7 +303,8 @@ describe('PassFinalisationCatDPage', () => {
     describe('onSubmit', () => {
       it('should dispatch the PersistTests action', () => {
         component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(PersistTests());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PersistTests());
       });
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
         component.form = new UntypedFormGroup({
@@ -305,8 +316,10 @@ describe('PassFinalisationCatDPage', () => {
 
         component.onSubmit();
         tick();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
         expect(store$.dispatch)
           .toHaveBeenCalledWith(PassFinalisationValidationError(`${PASS_CERTIFICATE_NUMBER_CTRL} is invalid`));
         expect(store$.dispatch)
@@ -320,8 +333,10 @@ describe('PassFinalisationCatDPage', () => {
           component.transmission = cat.transmission;
           component.code78Present = cat.code78;
           component.testCategory = cat.category;
-          expect(component.shouldShowAutomaticBanner()).toEqual(cat.automaticBanner);
-          expect(component.shouldShowManualBanner()).toEqual(cat.manualBanner);
+          expect(component.shouldShowAutomaticBanner())
+            .toEqual(cat.automaticBanner);
+          expect(component.shouldShowManualBanner())
+            .toEqual(cat.manualBanner);
         });
       });
     });
@@ -351,14 +366,16 @@ describe('PassFinalisationCatDPage', () => {
         component.merged$ = new Observable<string | boolean>();
         component.ionViewWillEnter();
 
-        expect(component.subscription).toBeDefined();
+        expect(component.subscription)
+          .toBeDefined();
       });
     });
 
     describe('shouldShowCandidateDoesntNeedLicenseBanner', () => {
       it('should return provisionalLicenseIsReceived', () => {
         component.provisionalLicenseIsReceived = true;
-        expect(component.shouldShowCandidateDoesntNeedLicenseBanner()).toEqual(true);
+        expect(component.shouldShowCandidateDoesntNeedLicenseBanner())
+          .toEqual(true);
       });
     });
 
@@ -367,14 +384,16 @@ describe('PassFinalisationCatDPage', () => {
         component.subscription = new Subscription();
         spyOn(component.subscription, 'unsubscribe');
         component.ionViewDidLeave();
-        expect(component.subscription.unsubscribe).toHaveBeenCalled();
+        expect(component.subscription.unsubscribe)
+          .toHaveBeenCalled();
       });
     });
 
     describe('shouldHideBanner', () => {
       it('should hide banner when only transmission is selected', () => {
         component.transmission = TransmissionType.Manual;
-        expect(component.shouldShowCode78Banner()).toEqual(false);
+        expect(component.shouldShowCode78Banner())
+          .toEqual(false);
       });
     });
   });

--- a/src/app/pages/pass-finalisation/cat-home-test/__tests__/pass-finalisation.cat-home-test.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-home-test/__tests__/pass-finalisation.cat-home-test.page.spec.ts
@@ -1,10 +1,5 @@
-import {
-  ComponentFixture, TestBed, waitForAsync, fakeAsync, tick,
-} from '@angular/core/testing';
-import {
-  NavControllerMock,
-  PlatformMock,
-} from '@mocks/index.mock';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { Store } from '@ngrx/store';
@@ -19,15 +14,11 @@ import { PracticeModeBanner } from '@components/common/practice-mode-banner/prac
 import {
   PassCertificateNumberComponent,
 } from '@pages/pass-finalisation/components/pass-certificate-number/pass-certificate-number';
-import {
-  LicenseProvidedComponent,
-} from '@pages/pass-finalisation/components/license-provided/license-provided';
+import { LicenseProvidedComponent } from '@pages/pass-finalisation/components/license-provided/license-provided';
 import {
   LicenceProvidedWarningBannerComponent,
 } from '@pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner';
-import {
-  NavController, Platform,
-} from '@ionic/angular';
+import { NavController, Platform } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { D255Component } from '@components/test-finalisation/d255/d255';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
@@ -35,7 +26,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/outcome-behaviour-map';
 import { PersistTests } from '@store/tests/tests.actions';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { PassFinalisationValidationError } from '@pages/pass-finalisation/pass-finalisation.actions';
 import {
   PASS_CERTIFICATE_NUMBER_CTRL,
@@ -48,7 +39,6 @@ describe('PassFinalisationCatHomeTestPage', () => {
   let fixture: ComponentFixture<PassFinalisationCatHomeTestPage>;
   let component: PassFinalisationCatHomeTestPage;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -71,10 +61,22 @@ describe('PassFinalisationCatHomeTestPage', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         OutcomeBehaviourMapProvider,
       ],
     });
@@ -89,7 +91,8 @@ describe('PassFinalisationCatHomeTestPage', () => {
     describe('onSubmit', () => {
       it('should dispatch the PersistTests action', () => {
         component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(PersistTests());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PersistTests());
       });
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
         component.form = new UntypedFormGroup({
@@ -101,8 +104,10 @@ describe('PassFinalisationCatHomeTestPage', () => {
 
         component.onSubmit();
         tick();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
         expect(store$.dispatch)
           .toHaveBeenCalledWith(PassFinalisationValidationError(`${PASS_CERTIFICATE_NUMBER_CTRL} is invalid`));
         expect(store$.dispatch)

--- a/src/app/pages/pass-finalisation/cat-manoeuvre/__tests__/pass-finalisation.cat-manoeuvre.page.spec.ts
+++ b/src/app/pages/pass-finalisation/cat-manoeuvre/__tests__/pass-finalisation.cat-manoeuvre.page.spec.ts
@@ -1,10 +1,5 @@
-import {
-  ComponentFixture, TestBed, waitForAsync, fakeAsync, tick,
-} from '@angular/core/testing';
-import {
-  NavControllerMock,
-  PlatformMock,
-} from '@mocks/index.mock';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { NavControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { Store } from '@ngrx/store';
@@ -18,15 +13,11 @@ import { PracticeModeBanner } from '@components/common/practice-mode-banner/prac
 import {
   PassCertificateNumberComponent,
 } from '@pages/pass-finalisation/components/pass-certificate-number/pass-certificate-number';
-import {
-  LicenseProvidedComponent,
-} from '@pages/pass-finalisation/components/license-provided/license-provided';
+import { LicenseProvidedComponent } from '@pages/pass-finalisation/components/license-provided/license-provided';
 import {
   LicenceProvidedWarningBannerComponent,
 } from '@pages/pass-finalisation/components/licence-provided-warning-banner/licence-provided-warning-banner';
-import {
-  NavController, Platform,
-} from '@ionic/angular';
+import { NavController, Platform } from '@ionic/angular';
 import { AppModule } from '@app/app.module';
 import { D255Component } from '@components/test-finalisation/d255/d255';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
@@ -34,7 +25,7 @@ import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/outcome-behaviour-map';
 import { PersistTests } from '@store/tests/tests.actions';
-import { UntypedFormGroup, UntypedFormControl, Validators } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { PassFinalisationValidationError } from '@pages/pass-finalisation/pass-finalisation.actions';
 import {
   PASS_CERTIFICATE_NUMBER_CTRL,
@@ -47,7 +38,6 @@ describe('PassFinalisationCatManoeuvrePage', () => {
   let fixture: ComponentFixture<PassFinalisationCatManoeuvrePage>;
   let component: PassFinalisationCatManoeuvrePage;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -69,10 +59,22 @@ describe('PassFinalisationCatManoeuvrePage', () => {
         AppModule,
       ],
       providers: [
-        { provide: Platform, useClass: PlatformMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: NavController, useClass: NavControllerMock },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: NavController,
+          useClass: NavControllerMock,
+        },
         OutcomeBehaviourMapProvider,
       ],
     });
@@ -87,7 +89,8 @@ describe('PassFinalisationCatManoeuvrePage', () => {
     describe('onSubmit', () => {
       it('should dispatch the PersistTests action', () => {
         component.onSubmit();
-        expect(store$.dispatch).toHaveBeenCalledWith(PersistTests());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PersistTests());
       });
       it('should dispatch the appropriate ValidationError actions', fakeAsync(() => {
         component.form = new UntypedFormGroup({
@@ -99,8 +102,10 @@ describe('PassFinalisationCatManoeuvrePage', () => {
 
         component.onSubmit();
         tick();
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
-        expect(store$.dispatch).toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl1 is blank'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(PassFinalisationValidationError('requiredControl2 is blank'));
         expect(store$.dispatch)
           .toHaveBeenCalledWith(PassFinalisationValidationError(`${PASS_CERTIFICATE_NUMBER_CTRL} is invalid`));
         expect(store$.dispatch)

--- a/src/app/pages/rekey-reason/__tests__/rekey-reason.page.spec.ts
+++ b/src/app/pages/rekey-reason/__tests__/rekey-reason.page.spec.ts
@@ -1,12 +1,10 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ModalController, Platform } from '@ionic/angular';
-import { ModalControllerMock, PlatformMock } from '@mocks/index.mock';
+import { ModalControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { Router } from '@angular/router';
 import { Store, StoreModule } from '@ngrx/store';
 import { MockComponent } from 'ng-mocks';
-import {
-  FormsModule, ReactiveFormsModule, UntypedFormControl, UntypedFormGroup,
-} from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, UntypedFormControl, UntypedFormGroup } from '@angular/forms';
 import { OverlayEventDetail } from '@ionic/core';
 
 import { AuthenticationProvider } from '@providers/authentication/authentication';
@@ -39,7 +37,8 @@ import { LoaderProviderMock } from '@providers/loader/__mocks__/loader.mock';
 import { UploadRekeyModal } from '@pages/rekey-reason/components/upload-rekey-modal/upload-rekey-modal';
 import { UploadRekeyModalEvent } from '@pages/rekey-reason/components/upload-rekey-modal/upload-rekey-modal.constants';
 import {
-  RekeyReasonViewDidEnter, RekeyUploadTest,
+  RekeyReasonViewDidEnter,
+  RekeyUploadTest,
   ResetStaffNumberValidationError,
   ValidateTransferRekey,
 } from '@pages/rekey-reason/rekey-reason.actions';
@@ -61,7 +60,6 @@ describe('RekeyReasonPage', () => {
   let modalController: ModalController;
   let store$: Store<AppInfoStateModel>;
   let router: Router;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -132,13 +130,34 @@ describe('RekeyReasonPage', () => {
         ReactiveFormsModule,
       ],
       providers: [
-        { provide: Router, useValue: routerSpy },
-        { provide: LoadingProvider, useClass: LoaderProviderMock },
-        { provide: Platform, useClass: PlatformMock },
-        { provide: AuthenticationProvider, useClass: AuthenticationProviderMock },
-        { provide: ModalController, useClass: ModalControllerMock },
-        { provide: FindUserProvider, useClass: FindUserProviderMock },
-        { provide: NavigationStateProvider, useClass: NavigationStateProviderMock },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: LoadingProvider,
+          useClass: LoaderProviderMock,
+        },
+        {
+          provide: Platform,
+          useClass: PlatformMock,
+        },
+        {
+          provide: AuthenticationProvider,
+          useClass: AuthenticationProviderMock,
+        },
+        {
+          provide: ModalController,
+          useClass: ModalControllerMock,
+        },
+        {
+          provide: FindUserProvider,
+          useClass: FindUserProviderMock,
+        },
+        {
+          provide: NavigationStateProvider,
+          useClass: NavigationStateProviderMock,
+        },
         Store,
       ],
     });
@@ -154,89 +173,107 @@ describe('RekeyReasonPage', () => {
 
   describe('Class', () => {
     it('should create', () => {
-      expect(component).toBeDefined();
+      expect(component)
+        .toBeDefined();
     });
     describe('ionViewDidEnter', () => {
       it('should dispatch the did enter action', () => {
         component.ionViewDidEnter();
-        expect(store$.dispatch).toHaveBeenCalledWith(RekeyReasonViewDidEnter());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(RekeyReasonViewDidEnter());
       });
     });
     describe('ipadIssueSelected', () => {
       it('should dispatch the ipad issue action', () => {
         component.ipadIssueSelected(true);
-        expect(store$.dispatch).toHaveBeenCalledWith(IpadIssueSelected(true));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(IpadIssueSelected(true));
       });
     });
     describe('ipadIssueTechnicalFaultChanged', () => {
       it('should dispatch the ipad tech fault action', () => {
         component.ipadIssueTechnicalFaultChanged();
-        expect(store$.dispatch).toHaveBeenCalledWith(IpadIssueTechFaultSelected());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(IpadIssueTechFaultSelected());
       });
     });
     describe('ipadIssueLostChanged', () => {
       it('should dispatch the ipad lost action', () => {
         component.ipadIssueLostChanged();
-        expect(store$.dispatch).toHaveBeenCalledWith(IpadIssueLostSelected());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(IpadIssueLostSelected());
       });
     });
     describe('ipadIssueStolenChanged', () => {
       it('should dispatch the ipad stolen action', () => {
         component.ipadIssueStolenChanged();
-        expect(store$.dispatch).toHaveBeenCalledWith(IpadIssueStolenSelected());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(IpadIssueStolenSelected());
       });
     });
     describe('ipadIssueBrokenChanged', () => {
       it('should dispatch the ipad broken selected action', () => {
         component.ipadIssueBrokenChanged();
-        expect(store$.dispatch).toHaveBeenCalledWith(IpadIssueBrokenSelected());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(IpadIssueBrokenSelected());
       });
     });
     describe('otherSelected', () => {
       it('should dispatch the other selected action', () => {
         component.otherSelected(true);
-        expect(store$.dispatch).toHaveBeenCalledWith(OtherSelected(true));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(OtherSelected(true));
       });
     });
     describe('otherReasonChanged', () => {
       it('should dispatch the other reason action', () => {
         component.otherReasonChanged('reason');
-        expect(store$.dispatch).toHaveBeenCalledWith(OtherReasonUpdated('reason'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(OtherReasonUpdated('reason'));
       });
     });
     describe('transferSelected', () => {
       it('should dispatch the transfer selected regardless of the value of isChecked', () => {
         component.transferSelected(true);
-        expect(store$.dispatch).toHaveBeenCalledWith(TransferSelected(true));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(TransferSelected(true));
       });
       it('should dispatch the set examiner conducted action only', () => {
         component.transferSelected(true);
-        expect(store$.dispatch).toHaveBeenCalledWith(SetExaminerConducted(null));
-        expect(store$.dispatch).not.toHaveBeenCalledWith(ResetStaffNumberValidationError());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(SetExaminerConducted(null));
+        expect(store$.dispatch)
+          .not
+          .toHaveBeenCalledWith(ResetStaffNumberValidationError());
       });
       it('should dispatch the set examiner with the examinerKeyed and the reset action', () => {
         component.transferSelected(false);
-        expect(store$.dispatch).toHaveBeenCalledWith(SetExaminerConducted(component.examinerKeyed));
-        expect(store$.dispatch).toHaveBeenCalledWith(ResetStaffNumberValidationError());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(SetExaminerConducted(component.examinerKeyed));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(ResetStaffNumberValidationError());
       });
     });
     describe('staffNumberChanged', () => {
       it('should dispatch the reset staff number action when isStaffNumberInvalid is true', () => {
         component.isStaffNumberInvalid = true;
         component.staffNumberChanged(123);
-        expect(store$.dispatch).toHaveBeenCalledWith(ResetStaffNumberValidationError());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(ResetStaffNumberValidationError());
       });
       it('should dispatch the set examiner action when isStaffNumberInvalid is false', () => {
         component.isStaffNumberInvalid = false;
         component.staffNumberChanged(123);
-        expect(store$.dispatch).toHaveBeenCalledWith(SetExaminerConducted(123));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(SetExaminerConducted(123));
       });
     });
     describe('onExitRekeyPressed', () => {
       it('should call through to showExitRekeyModal', async () => {
         spyOn(component, 'showExitRekeyModal');
         await component.onExitRekeyPressed();
-        expect(component.showExitRekeyModal).toHaveBeenCalled();
+        expect(component.showExitRekeyModal)
+          .toHaveBeenCalled();
       });
     });
     describe('onExitRekeyModalDismiss', () => {
@@ -245,54 +282,71 @@ describe('RekeyReasonPage', () => {
       });
       it('should not call exitRekey when modal event is CANCEL', async () => {
         await component.onExitRekeyModalDismiss(ExitRekeyModalEvent.CANCEL);
-        expect(component.exitRekey).not.toHaveBeenCalled();
+        expect(component.exitRekey)
+          .not
+          .toHaveBeenCalled();
       });
       it('should call exitRekey when modal event is EXIT_REKEY', async () => {
         await component.onExitRekeyModalDismiss(ExitRekeyModalEvent.EXIT_REKEY);
-        expect(component.exitRekey).toHaveBeenCalled();
+        expect(component.exitRekey)
+          .toHaveBeenCalled();
       });
     });
     describe('canClickUploadRekeyTest', () => {
       it('should return true if any of ipadIssue/transfer/other are selected', async () => {
-        expect(component.canClickUploadRekeyTest({ selected: true }, null, null)).toEqual(true);
-        expect(component.canClickUploadRekeyTest(null, { selected: true }, null)).toEqual(true);
-        expect(component.canClickUploadRekeyTest(null, null, { selected: true })).toEqual(true);
-        expect(component.canClickUploadRekeyTest(null, null, null)).toEqual(false);
+        expect(component.canClickUploadRekeyTest({ selected: true }, null, null))
+          .toEqual(true);
+        expect(component.canClickUploadRekeyTest(null, { selected: true }, null))
+          .toEqual(true);
+        expect(component.canClickUploadRekeyTest(null, null, { selected: true }))
+          .toEqual(true);
+        expect(component.canClickUploadRekeyTest(null, null, null))
+          .toEqual(false);
       });
     });
     describe('showExitRekeyModal', () => {
       it('should display an exit rekey modal', async () => {
-        spyOn(modalController, 'create').and.returnValue(Promise.resolve({
-          present: async () => {},
-          onDidDismiss: () => ({ data: 'cancel' }) as OverlayEventDetail,
-        } as HTMLIonModalElement));
+        spyOn(modalController, 'create')
+          .and
+          .returnValue(Promise.resolve({
+            present: async () => {
+            },
+            onDidDismiss: () => ({ data: 'cancel' }) as OverlayEventDetail,
+          } as HTMLIonModalElement));
         spyOn(component, 'onExitRekeyModalDismiss');
 
         await component.showExitRekeyModal();
 
-        expect(modalController.create).toHaveBeenCalledWith({
-          component: ExitRekeyModal,
-          cssClass: 'mes-modal-alert text-zoom-regular',
-        });
-        expect(component.onExitRekeyModalDismiss).toHaveBeenCalledWith('cancel' as ExitRekeyModalEvent);
+        expect(modalController.create)
+          .toHaveBeenCalledWith({
+            component: ExitRekeyModal,
+            cssClass: 'mes-modal-alert text-zoom-regular',
+          });
+        expect(component.onExitRekeyModalDismiss)
+          .toHaveBeenCalledWith('cancel' as ExitRekeyModalEvent);
       });
     });
     describe('onShowUploadRekeyModal', () => {
       it('should display an upload modal', async () => {
-        spyOn(modalController, 'create').and.returnValue(Promise.resolve({
-          present: async () => {},
-          onDidDismiss: () => ({ data: 'cancel' }) as OverlayEventDetail,
-        } as HTMLIonModalElement));
+        spyOn(modalController, 'create')
+          .and
+          .returnValue(Promise.resolve({
+            present: async () => {
+            },
+            onDidDismiss: () => ({ data: 'cancel' }) as OverlayEventDetail,
+          } as HTMLIonModalElement));
         spyOn(component, 'onUploadRekeyModalDismiss');
 
         await component.onShowUploadRekeyModal(true);
 
-        expect(modalController.create).toHaveBeenCalledWith({
-          component: UploadRekeyModal,
-          componentProps: { retryMode: true },
-          cssClass: 'mes-modal-alert text-zoom-regular',
-        });
-        expect(component.onUploadRekeyModalDismiss).toHaveBeenCalledWith('cancel' as UploadRekeyModalEvent);
+        expect(modalController.create)
+          .toHaveBeenCalledWith({
+            component: UploadRekeyModal,
+            componentProps: { retryMode: true },
+            cssClass: 'mes-modal-alert text-zoom-regular',
+          });
+        expect(component.onUploadRekeyModalDismiss)
+          .toHaveBeenCalledWith('cancel' as UploadRekeyModalEvent);
       });
     });
     describe('ionViewWillEnter', () => {
@@ -300,7 +354,8 @@ describe('RekeyReasonPage', () => {
         component.merged$ = new Observable<string | boolean>();
         component.ionViewWillEnter();
 
-        expect(component.subscription).toBeDefined();
+        expect(component.subscription)
+          .toBeDefined();
       });
     });
     describe('isFormValid', () => {
@@ -308,7 +363,8 @@ describe('RekeyReasonPage', () => {
         spyOn(component, 'markSpecificControlsAsDirty');
         component.isFormValid();
 
-        expect(component.markSpecificControlsAsDirty).toHaveBeenCalled();
+        expect(component.markSpecificControlsAsDirty)
+          .toHaveBeenCalled();
       });
     });
     describe('ionViewDidLeave', () => {
@@ -316,32 +372,43 @@ describe('RekeyReasonPage', () => {
         component.subscription = new Subscription();
         spyOn(component.subscription, 'unsubscribe');
         component.ionViewDidLeave();
-        expect(component.subscription.unsubscribe).toHaveBeenCalled();
+        expect(component.subscription.unsubscribe)
+          .toHaveBeenCalled();
       });
     });
     describe('onUploadRekeyModalDismiss', () => {
       it('should dispatch and SetRekeyDate and ValidateTransferRekey if '
-          + 'passed parameter is UploadRekeyModalEvent.UPLOAD and isTransferSelected is true', () => {
+        + 'passed parameter is UploadRekeyModalEvent.UPLOAD and isTransferSelected is true', () => {
         component.isTransferSelected = true;
         component.onUploadRekeyModalDismiss(UploadRekeyModalEvent.UPLOAD);
-        expect(store$.dispatch).toHaveBeenCalledWith(SetRekeyDate());
-        expect(store$.dispatch).toHaveBeenCalledWith(ValidateTransferRekey());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(SetRekeyDate());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(ValidateTransferRekey());
       });
       it('should dispatch and SetRekeyDate, SendCurrentTest and RekeyUploadTest if '
-          + 'passed parameter is UploadRekeyModalEvent.UPLOAD and isTransferSelected is false', () => {
+        + 'passed parameter is UploadRekeyModalEvent.UPLOAD and isTransferSelected is false', () => {
         component.isTransferSelected = false;
         component.onUploadRekeyModalDismiss(UploadRekeyModalEvent.UPLOAD);
-        expect(store$.dispatch).toHaveBeenCalledWith(SetRekeyDate());
-        expect(store$.dispatch).toHaveBeenCalledWith(SendCurrentTest());
-        expect(store$.dispatch).toHaveBeenCalledWith(RekeyUploadTest());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(SetRekeyDate());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(SendCurrentTest());
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(RekeyUploadTest());
       });
     });
     describe('onUploadPressed', () => {
       it('should call onShowUploadRekeyModal if isFormValid is true', async () => {
-        spyOn(component, 'isFormValid').and.returnValue(true);
-        spyOn(component, 'onShowUploadRekeyModal').and.callThrough();
+        spyOn(component, 'isFormValid')
+          .and
+          .returnValue(true);
+        spyOn(component, 'onShowUploadRekeyModal')
+          .and
+          .callThrough();
         await component.onUploadPressed();
-        expect(component.onShowUploadRekeyModal).toHaveBeenCalled();
+        expect(component.onShowUploadRekeyModal)
+          .toHaveBeenCalled();
       });
     });
     describe('exitRekey', () => {
@@ -350,14 +417,16 @@ describe('RekeyReasonPage', () => {
         component.fromRekeySearch = true;
         await component.exitRekey();
 
-        expect(component.router.navigate).toHaveBeenCalledWith([REKEY_SEARCH_PAGE]);
+        expect(component.router.navigate)
+          .toHaveBeenCalledWith([REKEY_SEARCH_PAGE]);
       });
       it('should run navigate with JOURNAL_PAGE if fromRekeySearch is false', async () => {
         spyOn(component.router, 'navigate');
         component.fromRekeySearch = false;
         await component.exitRekey();
 
-        expect(component.router.navigate).toHaveBeenCalledWith([JOURNAL_PAGE]);
+        expect(component.router.navigate)
+          .toHaveBeenCalledWith([JOURNAL_PAGE]);
       });
     });
     describe('markSpecificControlsAsDirty', () => {
@@ -371,13 +440,18 @@ describe('RekeyReasonPage', () => {
           transferSelected: new UntypedFormControl(),
           otherSelected: new UntypedFormControl(),
         });
-        component.formGroup.get('ipadIssueSelected').setValue('1');
+        component.formGroup.get('ipadIssueSelected')
+          .setValue('1');
         component.markSpecificControlsAsDirty();
 
-        expect(component.formGroup.get('ipadIssueTechnicalFault').dirty).toEqual(true);
-        expect(component.formGroup.get('ipadIssueLost').dirty).toEqual(true);
-        expect(component.formGroup.get('ipadIssueStolen').dirty).toEqual(true);
-        expect(component.formGroup.get('ipadIssueBroken').dirty).toEqual(true);
+        expect(component.formGroup.get('ipadIssueTechnicalFault').dirty)
+          .toEqual(true);
+        expect(component.formGroup.get('ipadIssueLost').dirty)
+          .toEqual(true);
+        expect(component.formGroup.get('ipadIssueStolen').dirty)
+          .toEqual(true);
+        expect(component.formGroup.get('ipadIssueBroken').dirty)
+          .toEqual(true);
       });
       it('should mark relevant fields as dirty if transferSelected is present ', () => {
         component.formGroup = new UntypedFormGroup({
@@ -386,10 +460,12 @@ describe('RekeyReasonPage', () => {
           otherSelected: new UntypedFormControl(),
           staffNumber: new UntypedFormControl(),
         });
-        component.formGroup.get('transferSelected').setValue('1');
+        component.formGroup.get('transferSelected')
+          .setValue('1');
         component.markSpecificControlsAsDirty();
 
-        expect(component.formGroup.get('staffNumber').dirty).toEqual(true);
+        expect(component.formGroup.get('staffNumber').dirty)
+          .toEqual(true);
       });
       it('should mark relevant fields as dirty if otherSelected is present ', () => {
         component.formGroup = new UntypedFormGroup({
@@ -398,10 +474,12 @@ describe('RekeyReasonPage', () => {
           otherSelected: new UntypedFormControl(),
           reason: new UntypedFormControl(),
         });
-        component.formGroup.get('otherSelected').setValue('1');
+        component.formGroup.get('otherSelected')
+          .setValue('1');
         component.markSpecificControlsAsDirty();
 
-        expect(component.formGroup.get('reason').dirty).toEqual(true);
+        expect(component.formGroup.get('reason').dirty)
+          .toEqual(true);
       });
     });
     describe('handleUploadOutcome', () => {
@@ -414,41 +492,64 @@ describe('RekeyReasonPage', () => {
         const result: RekeyReasonModel = rekeyReasonReducer(null, action);
         const uploadStatus = getUploadStatus(result);
         await component.handleUploadOutcome(uploadStatus);
-        expect(loaderService.handleUILoading).toHaveBeenCalledWith(
-          true, { spinner: 'circles', message: 'Uploading...' },
-        );
+        expect(loaderService.handleUILoading)
+          .toHaveBeenCalledWith(
+            true, {
+              spinner: 'circles',
+              message: 'Uploading...',
+            },
+          );
       });
       it('should display the retry modal when an upload fails', async () => {
         const action = SendCurrentTestFailure(false);
         const result: RekeyReasonModel = rekeyReasonReducer(null, action);
         const uploadStatus = getUploadStatus(result);
         await component.handleUploadOutcome(uploadStatus);
-        expect(loaderService.handleUILoading).toHaveBeenCalledWith(
-          false, { spinner: 'circles', message: 'Uploading...' },
-        );
-        expect(component.onShowUploadRekeyModal).toHaveBeenCalledWith(true);
+        expect(loaderService.handleUILoading)
+          .toHaveBeenCalledWith(
+            false, {
+              spinner: 'circles',
+              message: 'Uploading...',
+            },
+          );
+        expect(component.onShowUploadRekeyModal)
+          .toHaveBeenCalledWith(true);
       });
       it('should navigate to the next page and not display the retry modal when an upload is a duplicate', async () => {
         const action = SendCurrentTestFailure(true);
         const result: RekeyReasonModel = rekeyReasonReducer(null, action);
         const uploadStatus = getUploadStatus(result);
         await component.handleUploadOutcome(uploadStatus);
-        expect(loaderService.handleUILoading).toHaveBeenCalledWith(
-          false, { spinner: 'circles', message: 'Uploading...' },
-        );
-        expect(router.navigate).toHaveBeenCalledWith([TestFlowPageNames.REKEY_UPLOAD_OUTCOME_PAGE]);
-        expect(component.onShowUploadRekeyModal).not.toHaveBeenCalled();
+        expect(loaderService.handleUILoading)
+          .toHaveBeenCalledWith(
+            false, {
+              spinner: 'circles',
+              message: 'Uploading...',
+            },
+          );
+        expect(router.navigate)
+          .toHaveBeenCalledWith([TestFlowPageNames.REKEY_UPLOAD_OUTCOME_PAGE]);
+        expect(component.onShowUploadRekeyModal)
+          .not
+          .toHaveBeenCalled();
       });
       it('should navigate to next page and not display the retry modal when an upload succeeds', async () => {
         const action = SendCurrentTestSuccess();
         const result: RekeyReasonModel = rekeyReasonReducer(null, action);
         const uploadStatus = getUploadStatus(result);
         await component.handleUploadOutcome(uploadStatus);
-        expect(loaderService.handleUILoading).toHaveBeenCalledWith(
-          false, { spinner: 'circles', message: 'Uploading...' },
-        );
-        expect(router.navigate).toHaveBeenCalledWith([TestFlowPageNames.REKEY_UPLOAD_OUTCOME_PAGE]);
-        expect(component.onShowUploadRekeyModal).not.toHaveBeenCalled();
+        expect(loaderService.handleUILoading)
+          .toHaveBeenCalledWith(
+            false, {
+              spinner: 'circles',
+              message: 'Uploading...',
+            },
+          );
+        expect(router.navigate)
+          .toHaveBeenCalledWith([TestFlowPageNames.REKEY_UPLOAD_OUTCOME_PAGE]);
+        expect(component.onShowUploadRekeyModal)
+          .not
+          .toHaveBeenCalled();
       });
     });
   });

--- a/src/app/pages/rekey-search/rekey-search.ts
+++ b/src/app/pages/rekey-search/rekey-search.ts
@@ -3,12 +3,10 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { TestSlot } from '@dvsa/mes-journal-schema';
 import { HttpErrorResponse } from '@angular/common/http';
-import { select, Store } from '@ngrx/store';
+import { select } from '@ngrx/store';
 import { isEmpty } from 'lodash';
-import { KeepAwake as Insomnia } from '@capacitor-community/keep-awake';
 
 import { RekeySearchError, RekeySearchErrorMessages } from '@pages/rekey-search/rekey-search-error-model';
-import { StoreModel } from '@shared/models/store.model';
 import { BasePageComponent } from '@shared/classes/base-page';
 import {
   RekeySearchClearState,
@@ -22,7 +20,6 @@ import {
   getIsLoading,
   getRekeySearchError,
 } from '@pages/rekey-search/rekey-search.selector';
-import { DeviceProvider } from '@providers/device/device';
 import { OrientationMonitorProvider } from '@providers/orientation-monitor/orientation-monitor.provider';
 
 interface RekeySearchPageState {
@@ -47,8 +44,6 @@ export class RekeySearchPage extends BasePageComponent implements OnInit {
 
   constructor(
     public orientationMonitorProvider: OrientationMonitorProvider,
-    private store$: Store<StoreModel>,
-    private deviceProvider: DeviceProvider,
     injector: Injector,
   ) {
     super(injector);
@@ -77,11 +72,7 @@ export class RekeySearchPage extends BasePageComponent implements OnInit {
 
   async ionViewDidEnter(): Promise<void> {
     this.store$.dispatch(RekeySearchViewDidEnter());
-
-    if (super.isIos()) {
-      await Insomnia.allowSleep();
-      await this.deviceProvider.disableSingleAppMode();
-    }
+    await super.unlockDevice();
   }
 
   async ionViewWillEnter() {

--- a/src/app/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.page.spec.ts
+++ b/src/app/pages/rekey-upload-outcome/__tests__/rekey-upload-outcome.page.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule, Platform } from '@ionic/angular';
-import { PlatformMock } from '@mocks/index.mock';
+import { PlatformMock, RouterMock } from '@mocks/index.mock';
 import { Store, StoreModule } from '@ngrx/store';
 import { of } from 'rxjs';
 import { By } from '@angular/platform-browser';
@@ -29,7 +29,6 @@ describe('RekeyUploadOutcomePage', () => {
   let store$: Store<StoreModel>;
   let deviceProvider: DeviceProvider;
   let router: Router;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigate']);
 
   beforeEach(waitForAsync(() => {
     jasmine.getEnv()
@@ -53,7 +52,7 @@ describe('RekeyUploadOutcomePage', () => {
         },
         {
           provide: Router,
-          useValue: routerSpy,
+          useClass: RouterMock,
         },
         {
           provide: AuthenticationProvider,

--- a/src/app/pages/rekey-upload-outcome/rekey-upload-outcome.page.ts
+++ b/src/app/pages/rekey-upload-outcome/rekey-upload-outcome.page.ts
@@ -1,7 +1,7 @@
 import { Component, Injector, OnInit } from '@angular/core';
 import { merge, Observable, Subscription } from 'rxjs';
 import { map, withLatestFrom } from 'rxjs/operators';
-import { select, Store } from '@ngrx/store';
+import { select } from '@ngrx/store';
 import { KeepAwake as Insomnia } from '@capacitor-community/keep-awake';
 import { ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
 import { TestSlot } from '@dvsa/mes-journal-schema';
@@ -9,8 +9,6 @@ import { isEmpty } from 'lodash';
 
 import { getRekeyReasonState } from '@pages/rekey-reason/rekey-reason.reducer';
 import { getUploadStatus } from '@store/tests/rekey-reason/rekey-reason.selector';
-import { StoreModel } from '@shared/models/store.model';
-import { DeviceProvider } from '@providers/device/device';
 import { EndRekey } from '@store/tests/rekey/rekey.actions';
 import { BasePageComponent } from '@shared/classes/base-page';
 import { RekeyUploadOutcomeViewDidEnter } from '@pages/rekey-upload-outcome/rekey-upload-outcome.actions';
@@ -44,11 +42,7 @@ export class RekeyUploadOutcomePage extends BasePageComponent implements OnInit 
   fromRekeySearch: boolean;
   subscription: Subscription = Subscription.EMPTY;
 
-  constructor(
-    private store$: Store<StoreModel>,
-    private deviceProvider: DeviceProvider,
-    injector: Injector,
-  ) {
+  constructor(injector: Injector) {
     super(injector);
   }
 

--- a/src/app/pages/test-centre-journal/__tests__/test-centre-journal.page.spec.ts
+++ b/src/app/pages/test-centre-journal/__tests__/test-centre-journal.page.spec.ts
@@ -31,6 +31,10 @@ import {
 } from '../test-centre-journal.actions';
 import { TestCentreJournalPage } from '../test-centre-journal.page';
 import { TestCentreJournalComponentsModule } from '../components/test-centre-journal-components.module';
+import { DeviceProvider } from '@providers/device/device';
+import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
+import { ActivatedRoute } from '@angular/router';
+import { ActivatedRouteMock } from '@mocks/angular-mocks/activated-route.mock';
 
 describe('TestCenterJournalPage', () => {
   let component: TestCentreJournalPage;
@@ -86,6 +90,18 @@ describe('TestCenterJournalPage', () => {
         {
           provide: AppConfigProvider,
           useClass: AppConfigProviderMock,
+        },
+        {
+          provide: DeviceProvider,
+          useClass: DeviceProviderMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: ActivatedRouteMock,
         },
         provideMockStore({ initialState }),
       ],

--- a/src/app/pages/test-centre-journal/test-centre-journal.page.ts
+++ b/src/app/pages/test-centre-journal/test-centre-journal.page.ts
@@ -1,15 +1,13 @@
 import { Component, Injector, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { LoadingController } from '@ionic/angular';
 import { merge, Observable, of, Subject, Subscription } from 'rxjs';
-import { select, Store } from '@ngrx/store';
+import { select } from '@ngrx/store';
 import { catchError, finalize, map, takeUntil, tap } from 'rxjs/operators';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NetworkStateProvider } from '@providers/network-state/network-state';
 import { TestCentreJournalProvider } from '@providers/test-centre-journal/test-centre-journal';
-import { LogHelper } from '@providers/logs/logs-helper';
 import { BasePageComponent } from '@shared/classes/base-page';
 import { TestCentre, TestCentreDetailResponse } from '@shared/models/test-centre-journal.model';
-import { StoreModel } from '@shared/models/store.model';
 import { Log, LogType } from '@shared/models/log.model';
 import { ErrorTypes } from '@shared/models/error-message';
 import { SaveLog } from '@store/logs/logs.actions';
@@ -70,8 +68,6 @@ export class TestCentreJournalPage extends BasePageComponent implements OnDestro
   constructor(
     public orientationMonitorProvider: OrientationMonitorProvider,
     private networkStateProvider: NetworkStateProvider,
-    private store$: Store<StoreModel>,
-    private logHelper: LogHelper,
     private testCentreJournalProvider: TestCentreJournalProvider,
     private loadingCtrl: LoadingController,
     private appConfig: AppConfigProvider,

--- a/src/app/pages/test-results-search/test-results-search.ts
+++ b/src/app/pages/test-results-search/test-results-search.ts
@@ -1,5 +1,5 @@
 import { ModalController } from '@ionic/angular';
-import { select, Store } from '@ngrx/store';
+import { select } from '@ngrx/store';
 import { Component, Injector } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { SearchResultTestSchema } from '@dvsa/mes-search-schema';
@@ -8,13 +8,11 @@ import { catchError, map, tap } from 'rxjs/operators';
 
 import { ErrorTypes } from '@shared/models/error-message';
 import { BasePageComponent } from '@shared/classes/base-page';
-import { StoreModel } from '@shared/models/store.model';
 import { LogType } from '@shared/models/log.model';
 import { MesError } from '@shared/models/mes-error.model';
 import { AppConfigProvider } from '@providers/app-config/app-config';
 import { SearchProvider } from '@providers/search/search';
 import { AdvancedSearchParams } from '@providers/search/search.models';
-import { LogHelper } from '@providers/logs/logs-helper';
 import { ExaminerRole } from '@providers/app-config/constants/examiner-role.constants';
 import { SaveLog } from '@store/logs/logs.actions';
 import { ErrorPage } from '@pages/error-page/error';
@@ -62,8 +60,6 @@ export class TestResultsSearchPage extends BasePageComponent {
     public modalController: ModalController,
     public searchProvider: SearchProvider,
     private appConfig: AppConfigProvider,
-    private store$: Store<StoreModel>,
-    private logHelper: LogHelper,
     private accessibilityService: AccessibilityService,
     injector: Injector,
   ) {

--- a/src/app/pages/unuploaded-tests/unuploaded-tests.page.ts
+++ b/src/app/pages/unuploaded-tests/unuploaded-tests.page.ts
@@ -1,8 +1,6 @@
 import { Component, Injector, OnInit } from '@angular/core';
 import { selectEmployeeId, selectEmployeeName, selectVersionNumber } from '@store/app-info/app-info.selectors';
 import { Observable } from 'rxjs';
-import { Store } from '@ngrx/store';
-import { StoreModel } from '@shared/models/store.model';
 import { map } from 'rxjs/operators';
 import { selectRole } from '@store/app-config/app-config.selectors';
 import { ExaminerRoleDescription } from '@providers/app-config/constants/examiner-role.constants';
@@ -13,8 +11,6 @@ import { unsubmittedTestSlotsInDateOrder$ } from '@pages/unuploaded-tests/unuplo
 import { DateTimeProvider } from '@providers/date-time/date-time';
 import { SlotProvider } from '@providers/slot/slot';
 import { BasePageComponent } from '@shared/classes/base-page';
-import { ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
-import { KeepAwake as Insomnia } from '@capacitor-community/keep-awake';
 import { DeviceProvider } from '@providers/device/device';
 import { OrientationMonitorProvider } from '@providers/orientation-monitor/orientation-monitor.provider';
 
@@ -37,7 +33,6 @@ export class UnuploadedTestsPage extends BasePageComponent implements OnInit {
 
   constructor(
     public orientationMonitorProvider: OrientationMonitorProvider,
-    private store$: Store<StoreModel>,
     private dateTimeProvider: DateTimeProvider,
     private slotProvider: SlotProvider,
     public deviceProvider: DeviceProvider,
@@ -70,12 +65,7 @@ export class UnuploadedTestsPage extends BasePageComponent implements OnInit {
 
   async ionViewDidEnter(): Promise<void> {
     this.store$.dispatch(UnuploadedTestsViewDidEnter());
-
-    if (super.isIos()) {
-      await ScreenOrientation.unlock();
-      await Insomnia.allowSleep();
-      await this.deviceProvider.disableSingleAppMode();
-    }
+    await super.unlockDevice();
   }
 
   getRoleDisplayValue = (role: string): string => ExaminerRoleDescription[role] || 'Unknown Role';

--- a/src/app/pages/view-test-result/view-test-result.page.ts
+++ b/src/app/pages/view-test-result/view-test-result.page.ts
@@ -4,15 +4,12 @@ import { BasePageComponent } from '@shared/classes/base-page';
 import * as moment from 'moment';
 import { get } from 'lodash';
 import { formatApplicationReference } from '@shared/helpers/formatters';
-import { StoreModel } from '@shared/models/store.model';
-import { Store } from '@ngrx/store';
 import { ViewTestResultViewDidEnter } from '@pages/view-test-result/view-test-result.actions';
 import { of, Subscription } from 'rxjs';
 import { SearchProvider } from '@providers/search/search';
 import { HttpResponse } from '@angular/common/http';
 import { CompressionProvider } from '@providers/compression/compression';
 import { catchError, map, tap } from 'rxjs/operators';
-import { LogHelper } from '@providers/logs/logs-helper';
 import { SaveLog } from '@store/logs/logs.actions';
 import { LogType } from '@shared/models/log.model';
 import { ErrorTypes } from '@shared/models/error-message';
@@ -66,10 +63,8 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
 
   constructor(
     public modalCtrl: ModalController,
-    private store$: Store<StoreModel>,
     private searchProvider: SearchProvider,
     private compressionProvider: CompressionProvider,
-    private logHelper: LogHelper,
     private loadingProvider: LoadingProvider,
     public faultCountProvider: FaultCountProvider,
     private faultSummaryProvider: FaultSummaryProvider,

--- a/src/app/pages/waiting-room/__tests__/waiting-room.page.spec.ts
+++ b/src/app/pages/waiting-room/__tests__/waiting-room.page.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { ModalController, Platform } from '@ionic/angular';
-import { PlatformMock } from '@mocks/index.mock';
+import { PlatformMock, RouterMock } from '@mocks/index.mock';
 import { Router } from '@angular/router';
 import { Store, StoreModule } from '@ngrx/store';
 import { Observable, Subscription } from 'rxjs';
@@ -67,7 +67,7 @@ describe('WaitingRoomPage', () => {
   let deviceAuthenticationProvider: DeviceAuthenticationProvider;
   let translate: TranslateService;
   let modalController: ModalController;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
+  let router: Router;
 
   const initialState = {
     appInfo: { employeeId: '123456' },
@@ -185,7 +185,7 @@ describe('WaitingRoomPage', () => {
       providers: [
         {
           provide: Router,
-          useValue: routerSpy,
+          useClass: RouterMock,
         },
         {
           provide: Platform,
@@ -223,6 +223,7 @@ describe('WaitingRoomPage', () => {
     translate.setDefaultLang('en');
     store$ = TestBed.inject(Store);
     modalController = TestBed.inject(ModalController);
+    router = TestBed.inject(Router);
     spyOn(store$, 'dispatch');
     component.subscription = new Subscription();
   }));
@@ -436,7 +437,7 @@ describe('WaitingRoomPage', () => {
         formGroup.get('insuranceCheckbox')
           .setValue(true);
         await component.onSubmit();
-        expect(routerSpy.navigate)
+        expect(router.navigate)
           .toHaveBeenCalledWith([TestFlowPageNames.CANDIDATE_LICENCE_PAGE]);
       });
       it('should dispatch the WaitingRoomValidationError action if a field is not valid', fakeAsync(() => {

--- a/src/app/providers/authentication/__mocks__/authentication.mock.ts
+++ b/src/app/providers/authentication/__mocks__/authentication.mock.ts
@@ -8,6 +8,10 @@ export class AuthenticationProviderMock {
     .and
     .returnValue(false);
 
+  getEmployeeIdFromIDToken = jasmine.createSpy('getEmployeeIdFromIDToken')
+    .and
+    .returnValue(Promise.resolve('1234567'));
+
   getAuthenticationToken = jasmine.createSpy('getAuthenticationToken')
     .and
     .returnValue(Promise.resolve('token'));

--- a/src/app/providers/authentication/authentication.ts
+++ b/src/app/providers/authentication/authentication.ts
@@ -270,6 +270,13 @@ export class AuthenticationProvider {
     }
   }
 
+  public getEmployeeIdFromIDToken = async () => {
+    // rerun logic for setting employee ID
+    await this.setEmployeeId();
+    // retrieve set employee ID
+    return this.getEmployeeId();
+  };
+
   public async setEmployeeId() {
     const idToken = await this.authConnect.getIdToken();
     const employeeId = idToken[this.employeeIdKey];
@@ -280,7 +287,7 @@ export class AuthenticationProvider {
 
   private logEvent = (logType: LogType, desc: string, msg: string) => {
     this.store$.dispatch(SaveLog({
-      payload: this.logHelper.createLog(logType, desc, `${AuthenticationProvider.name} => ${msg}`),
+      payload: this.logHelper.createLog(logType, desc, `AuthenticationProvider => ${msg}`),
     }));
   };
 

--- a/src/app/sentry-error-handler.ts
+++ b/src/app/sentry-error-handler.ts
@@ -1,6 +1,4 @@
-import {
-  ErrorHandler, Inject, Injectable, Injector,
-} from '@angular/core';
+import { ErrorHandler, Inject, Injectable, Injector } from '@angular/core';
 import * as Sentry from '@sentry/capacitor';
 import { AppConfigProvider } from '@providers/app-config/app-config';
 import { AppInfoProvider } from '@providers/app-info/app-info';
@@ -52,7 +50,7 @@ export class SentryIonicErrorHandler extends ErrorHandler {
       }
 
       const role = this.appConfigProvider.getAppConfig()?.role;
-      const employeeID = this.authenticationProvider.getEmployeeId();
+      const employeeID = await this.authenticationProvider.getEmployeeIdFromIDToken();
       const appVersion = await this.appInfoProvider.getFullVersionNumber();
 
       Sentry.withScope((scope) => {

--- a/src/app/shared/classes/__tests__/base-page.spec.ts
+++ b/src/app/shared/classes/__tests__/base-page.spec.ts
@@ -1,6 +1,6 @@
 import { fakeAsync, flushMicrotasks, TestBed, waitForAsync } from '@angular/core/testing';
 import { Platform } from '@ionic/angular';
-import { Router } from '@angular/router';
+import { ActivatedRoute, Data, Router } from '@angular/router';
 import { AuthenticationProvider } from '@providers/authentication/authentication';
 import { AuthenticationProviderMock } from '@providers/authentication/__mocks__/authentication.mock';
 import { RouterMock } from '@mocks/angular-mocks/router-mock';
@@ -8,13 +8,33 @@ import { PlatformMock } from '@mocks/ionic-mocks/platform-mock';
 import { BasePageComponent } from '../base-page';
 import { Injector } from '@angular/core';
 import { LOGIN_PAGE } from '@pages/page-names.constants';
+import { DeviceProvider } from '@providers/device/device';
+import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
+import { LogHelper } from '@providers/logs/logs-helper';
+import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
+import { provideMockStore } from '@ngrx/store/testing';
+import { OrientationType, ScreenOrientation } from '@capawesome/capacitor-screen-orientation';
+import { KeepAwake as Insomnia } from '@capacitor-community/keep-awake';
+import { StoreModel } from '@shared/models/store.model';
+import { Store } from '@ngrx/store';
+import { LogType } from '@shared/models/log.model';
 
 describe('BasePageComponent', () => {
   let platform: Platform;
   let authenticationProvider: AuthenticationProvider;
   let injector: Injector;
   let router: Router;
+  let deviceProvider: DeviceProvider;
+  let logHelper: LogHelper;
+  let store$: Store<StoreModel>;
   let basePageComponent: BasePageComponent;
+  const activatedRouteMock = {
+    snapshot: {
+      ['_routerState']: {
+        url: '/test',
+      },
+    } as Data,
+  } as ActivatedRoute;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -31,6 +51,19 @@ describe('BasePageComponent', () => {
           provide: Router,
           useClass: RouterMock,
         },
+        {
+          provide: DeviceProvider,
+          useClass: DeviceProviderMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: activatedRouteMock,
+        },
+        provideMockStore({}),
       ],
     });
 
@@ -38,9 +71,15 @@ describe('BasePageComponent', () => {
     injector = TestBed.inject(Injector);
     authenticationProvider = TestBed.inject(AuthenticationProvider);
     router = TestBed.inject(Router);
+    deviceProvider = TestBed.inject(DeviceProvider);
+    store$ = TestBed.inject(Store);
+    logHelper = TestBed.inject(LogHelper);
     router.navigate = jasmine.createSpy()
       .and
       .returnValue(Promise.resolve(true));
+
+    spyOn(store$, 'dispatch');
+    spyOn(logHelper, 'createLog');
 
     class BasePageClass extends BasePageComponent {
       constructor(inj: Injector) {
@@ -55,10 +94,10 @@ describe('BasePageComponent', () => {
     it('should allow user access if authentication is not required', fakeAsync(() => {
       basePageComponent.loginRequired = false;
       basePageComponent.ionViewWillEnter();
+      flushMicrotasks();
       expect(router.navigate)
         .not
         .toHaveBeenCalled();
-      flushMicrotasks();
     }));
 
     it('should allow user access if authentication is required and device is not ios', fakeAsync(() => {
@@ -79,12 +118,13 @@ describe('BasePageComponent', () => {
         .and
         .returnValue(Promise.resolve(false));
       basePageComponent.ionViewWillEnter();
+      flushMicrotasks();
+
       expect(router.navigate)
         .not
         .toHaveBeenCalled();
-      flushMicrotasks();
     }));
-    it('should not allow access if user is not authd, auth is required and is ios', fakeAsync(() => {
+    it('should not allow access if user is not authed, auth is required and is ios', fakeAsync(() => {
       basePageComponent.isIos = jasmine.createSpy()
         .and
         .returnValue(true);
@@ -100,7 +140,8 @@ describe('BasePageComponent', () => {
       basePageComponent.ionViewWillEnter();
       flushMicrotasks();
       expect(router.navigate)
-        .toHaveBeenCalledWith([LOGIN_PAGE], { replaceUrl: true,
+        .toHaveBeenCalledWith([LOGIN_PAGE], {
+          replaceUrl: true,
           state: {
             hasLoggedOut: false,
             invalidToken: true,
@@ -158,6 +199,186 @@ describe('BasePageComponent', () => {
         .toHaveBeenCalledTimes(0);
       expect(router.navigate)
         .toHaveBeenCalledTimes(0);
+    });
+  });
+
+  describe('lockDevice', () => {
+    beforeEach(() => {
+      spyOn(ScreenOrientation, 'lock')
+        .and
+        .returnValue(Promise.resolve());
+      spyOn(Insomnia, 'keepAwake')
+        .and
+        .returnValue(Promise.resolve());
+    });
+
+    it('should lock device and keep awake in practice mode, but not single app mode', async () => {
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(true);
+
+      await basePageComponent.lockDevice(true);
+
+      expect(ScreenOrientation.lock)
+        .toHaveBeenCalledWith({ type: OrientationType.PORTRAIT_PRIMARY });
+      expect(Insomnia.keepAwake)
+        .toHaveBeenCalled();
+      expect(deviceProvider.enableSingleAppMode)
+        .not
+        .toHaveBeenCalled();
+    });
+    it('should lock device, keep awake and call single app mode when not practice mode', async () => {
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(true);
+
+      spyOn(deviceProvider, 'enableSingleAppMode')
+        .and
+        .returnValue(Promise.resolve(true));
+
+      await basePageComponent.lockDevice(false);
+
+      expect(ScreenOrientation.lock)
+        .toHaveBeenCalledWith({ type: OrientationType.PORTRAIT_PRIMARY });
+      expect(Insomnia.keepAwake)
+        .toHaveBeenCalled();
+      expect(deviceProvider.enableSingleAppMode)
+        .toHaveBeenCalled();
+    });
+    it('should capture thrown errors with page name and method', async () => {
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(true);
+
+      spyOn(deviceProvider, 'enableSingleAppMode')
+        .and
+        .returnValue(Promise.reject(new Error('Thrown err')));
+
+      await basePageComponent.lockDevice(false);
+
+      expect(store$.dispatch)
+        .toHaveBeenCalled();
+      expect(logHelper.createLog)
+        .toHaveBeenCalledWith(
+          LogType.ERROR,
+          'BasePageComponent => /test => lockDevice',
+          jasmine.stringContaining('Thrown err'),
+        );
+    });
+
+    it('should not run logic for locking when not in iOS', async () => {
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(false);
+
+      await basePageComponent.lockDevice(false);
+
+      expect(ScreenOrientation.lock)
+        .not
+        .toHaveBeenCalled();
+      expect(Insomnia.keepAwake)
+        .not
+        .toHaveBeenCalled();
+      expect(deviceProvider.enableSingleAppMode)
+        .not
+        .toHaveBeenCalled();
+      expect(store$.dispatch)
+        .not
+        .toHaveBeenCalled();
+    });
+  });
+
+  describe('unlockDevice', () => {
+    beforeEach(() => {
+      spyOn(ScreenOrientation, 'unlock')
+        .and
+        .returnValue(Promise.resolve());
+      spyOn(Insomnia, 'allowSleep')
+        .and
+        .returnValue(Promise.resolve());
+      spyOn(deviceProvider, 'disableSingleAppMode')
+        .and
+        .returnValue(Promise.resolve(true));
+    });
+
+    it('should disable SAM, but if it fails then do not call unlock and sleep again', async () => {
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(true);
+
+      spyOn(deviceProvider, 'isSAMEnabled')
+        .and
+        .returnValue(Promise.resolve(true));
+
+      await basePageComponent.unlockDevice();
+
+      expect(deviceProvider.disableSingleAppMode)
+        .toHaveBeenCalled();
+      expect(ScreenOrientation.unlock)
+        .not
+        .toHaveBeenCalledWith();
+      expect(Insomnia.allowSleep)
+        .not
+        .toHaveBeenCalled();
+    });
+    it('should call SAM, when that succeeds then call unlock and allow sleep', async () => {
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(true);
+
+      spyOn(deviceProvider, 'isSAMEnabled')
+        .and
+        .returnValue(Promise.resolve(false));
+
+      await basePageComponent.unlockDevice();
+
+      expect(deviceProvider.disableSingleAppMode)
+        .toHaveBeenCalled();
+      expect(ScreenOrientation.unlock)
+        .toHaveBeenCalledWith();
+      expect(Insomnia.allowSleep)
+        .toHaveBeenCalled();
+    });
+    it('should capture thrown errors with page name and method', async () => {
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(true);
+
+      spyOn(deviceProvider, 'disableSingleAppMode')
+        .and
+        .returnValue(Promise.reject(new Error('Thrown err')));
+
+      await basePageComponent.unlockDevice();
+
+      expect(store$.dispatch)
+        .toHaveBeenCalled();
+      expect(logHelper.createLog)
+        .toHaveBeenCalledWith(
+          LogType.ERROR,
+          'BasePageComponent => /test => unlockDevice',
+          jasmine.stringContaining('Thrown err'),
+        );
+    });
+
+    it('should not run logic for unlocking when not in iOS', async () => {
+      basePageComponent.isIos = jasmine.createSpy()
+        .and
+        .returnValue(false);
+
+      await basePageComponent.unlockDevice();
+
+      expect(ScreenOrientation.unlock)
+        .not
+        .toHaveBeenCalled();
+      expect(Insomnia.allowSleep)
+        .not
+        .toHaveBeenCalled();
+      expect(deviceProvider.disableSingleAppMode)
+        .not
+        .toHaveBeenCalled();
+      expect(store$.dispatch)
+        .not
+        .toHaveBeenCalled();
     });
   });
 

--- a/src/app/shared/classes/practiceable-base-page.ts
+++ b/src/app/shared/classes/practiceable-base-page.ts
@@ -16,9 +16,7 @@ interface PracticeableBasePageState {
 }
 
 @Injectable()
-export abstract class PracticeableBasePageComponent
-  extends BasePageComponent
-  implements OnInit, ViewDidLeave {
+export abstract class PracticeableBasePageComponent extends BasePageComponent implements OnInit, ViewDidLeave {
 
   public store$ = this.injector.get<Store<StoreModel>>(Store);
 

--- a/src/app/shared/classes/test-flow-base-pages/office/__tests__/office-base-page.spec.ts
+++ b/src/app/shared/classes/test-flow-base-pages/office/__tests__/office-base-page.spec.ts
@@ -1,8 +1,8 @@
 import { fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { ModalController, NavController, Platform, ToastController } from '@ionic/angular';
 import { Store } from '@ngrx/store';
-import { ModalControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
-import { Router } from '@angular/router';
+import { ActivatedRouteMock, ModalControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
 
@@ -82,6 +82,8 @@ import { OfficeBasePageComponent } from '../office-base-page';
 import { Injector } from '@angular/core';
 import { DeviceProvider } from '@providers/device/device';
 import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
+import { LogHelper } from '@providers/logs/logs-helper';
+import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
 
 describe('OfficeBasePageComponent', () => {
   let injector: Injector;
@@ -166,6 +168,14 @@ describe('OfficeBasePageComponent', () => {
         {
           provide: DeviceProvider,
           useClass: DeviceProviderMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: ActivatedRouteMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
         },
       ],
     });

--- a/src/app/shared/classes/test-flow-base-pages/pass-finalisation/__tests__/pass-finalisation-base-page.spec.ts
+++ b/src/app/shared/classes/test-flow-base-pages/pass-finalisation/__tests__/pass-finalisation-base-page.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { Platform } from '@ionic/angular';
 import { Store } from '@ngrx/store';
-import { PlatformMock } from '@mocks/index.mock';
-import { Router } from '@angular/router';
+import { ActivatedRouteMock, PlatformMock } from '@mocks/index.mock';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
 
@@ -33,6 +33,10 @@ import { RouteByCategoryProviderMock } from '@providers/route-by-category/__mock
 import { RouteByCategoryProvider } from '@providers/route-by-category/route-by-category';
 import { OutcomeBehaviourMapProviderMock } from '@providers/outcome-behaviour-map/__mocks__/outcome-behaviour-map.mock';
 import { OutcomeBehaviourMapProvider } from '@providers/outcome-behaviour-map/outcome-behaviour-map';
+import { DeviceProvider } from '@providers/device/device';
+import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
+import { LogHelper } from '@providers/logs/logs-helper';
+import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
 
 describe('PassFinalisationPageComponent', () => {
   let injector: Injector;
@@ -82,6 +86,18 @@ describe('PassFinalisationPageComponent', () => {
         {
           provide: OutcomeBehaviourMapProvider,
           useClass: OutcomeBehaviourMapProviderMock,
+        },
+        {
+          provide: DeviceProvider,
+          useClass: DeviceProviderMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: ActivatedRouteMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
         },
         provideMockStore({ initialState }),
       ],

--- a/src/app/shared/classes/test-flow-base-pages/pass-finalisation/__tests__/pass-finalisation-base-page.spec.ts
+++ b/src/app/shared/classes/test-flow-base-pages/pass-finalisation/__tests__/pass-finalisation-base-page.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { Platform } from '@ionic/angular';
 import { Store } from '@ngrx/store';
-import { ActivatedRouteMock, PlatformMock } from '@mocks/index.mock';
+import { ActivatedRouteMock, PlatformMock, RouterMock } from '@mocks/index.mock';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
@@ -41,7 +41,6 @@ import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
 describe('PassFinalisationPageComponent', () => {
   let injector: Injector;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   let basePageComponent: PassFinalisationPageComponent;
   const initialState = {
@@ -77,7 +76,7 @@ describe('PassFinalisationPageComponent', () => {
         },
         {
           provide: Router,
-          useValue: routerSpy,
+          useClass: RouterMock,
         },
         {
           provide: RouteByCategoryProvider,

--- a/src/app/shared/classes/test-flow-base-pages/test-report/__tests__/test-report-base-page.spec.ts
+++ b/src/app/shared/classes/test-flow-base-pages/test-report/__tests__/test-report-base-page.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { ModalController, Platform } from '@ionic/angular';
-import { ModalControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
-import { Router } from '@angular/router';
+import { ActivatedRouteMock, ModalControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
+import { ActivatedRoute, Router } from '@angular/router';
 import { provideMockStore } from '@ngrx/store/testing';
 import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
 
@@ -18,6 +18,10 @@ import { Injector } from '@angular/core';
 import { TestReportBasePageComponent } from '../test-report-base-page';
 import { TestReportValidatorProviderMock } from '@providers/test-report-validator/__mocks__/test-report-validator.mock';
 import { TestReportValidatorProvider } from '@providers/test-report-validator/test-report-validator';
+import { DeviceProvider } from '@providers/device/device';
+import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
+import { LogHelper } from '@providers/logs/logs-helper';
+import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
 
 describe('TestReportBasePageComponent', () => {
   let injector: Injector;
@@ -68,6 +72,18 @@ describe('TestReportBasePageComponent', () => {
         {
           provide: TestReportValidatorProvider,
           useClass: TestReportValidatorProviderMock,
+        },
+        {
+          provide: DeviceProvider,
+          useClass: DeviceProviderMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: ActivatedRouteMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
         },
         provideMockStore({ initialState }),
       ],

--- a/src/app/shared/classes/test-flow-base-pages/waiting-room-to-car/__tests__/waiting-room-to-car-base-page.spec.ts
+++ b/src/app/shared/classes/test-flow-base-pages/waiting-room-to-car/__tests__/waiting-room-to-car-base-page.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { AlertController, Platform } from '@ionic/angular';
 import { Store } from '@ngrx/store';
-import { AlertControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
-import { Router } from '@angular/router';
+import { ActivatedRouteMock, AlertControllerMock, PlatformMock, RouterMock } from '@mocks/index.mock';
+import { ActivatedRoute, Router } from '@angular/router';
 import { MockStore, provideMockStore } from '@ngrx/store/testing';
 import { Subscription } from 'rxjs';
 import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
@@ -59,6 +59,10 @@ import {
 import { WaitingRoomToCarBasePageComponent } from '../waiting-room-to-car-base-page';
 import { Injector } from '@angular/core';
 import { FaultCountProvider } from '@providers/fault-count/fault-count';
+import { DeviceProvider } from '@providers/device/device';
+import { DeviceProviderMock } from '@providers/device/__mocks__/device.mock';
+import { LogHelper } from '@providers/logs/logs-helper';
+import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
 
 describe('WaitingRoomToCarBasePageComponent', () => {
   let router: Router;
@@ -127,6 +131,18 @@ describe('WaitingRoomToCarBasePageComponent', () => {
         {
           provide: AlertController,
           useClass: AlertControllerMock,
+        },
+        {
+          provide: DeviceProvider,
+          useClass: DeviceProviderMock,
+        },
+        {
+          provide: ActivatedRoute,
+          useClass: ActivatedRouteMock,
+        },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
         },
         FaultCountProvider,
         provideMockStore({ initialState }),

--- a/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
+++ b/src/components/common/practice-mode-banner/__tests__/practice-mode-banner.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed, waitForAsync, ComponentFixture } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -7,11 +7,12 @@ import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/
 
 import { CategoryWhitelistProvider } from '@providers/category-whitelist/category-whitelist';
 import { PracticeModeBanner } from '../practice-mode-banner';
+import { RouterMock } from '@mocks/angular-mocks/router-mock';
 
 describe('PracticeModeBanner', () => {
   let fixture: ComponentFixture<PracticeModeBanner>;
   let component: PracticeModeBanner;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
+  let router: Router;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
@@ -24,20 +25,26 @@ describe('PracticeModeBanner', () => {
         }),
       })],
       providers: [
-        { provide: Router, useValue: routerSpy },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
         CategoryWhitelistProvider,
       ],
     });
 
     fixture = TestBed.createComponent(PracticeModeBanner);
+    router = TestBed.inject(Router);
     component = fixture.componentInstance;
   }));
 
   describe('Class', () => {
     describe('exitPracticeMode', () => {
-      it('should take the user back to the root page', () => {
-        component.exitPracticeMode();
-        expect(routerSpy.navigate).toHaveBeenCalled();
+      it('should take the user back to the root page', async () => {
+        spyOn(router, 'navigate');
+        await component.exitPracticeMode();
+        expect(router.navigate)
+          .toHaveBeenCalled();
       });
     });
   });

--- a/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
+++ b/src/components/test-slot/test-outcome/__tests__/test-outcome.spec.ts
@@ -1,6 +1,4 @@
-import {
-  ComponentFixture, waitForAsync, TestBed,
-} from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Store, StoreModule } from '@ngrx/store';
 import { By } from '@angular/platform-browser';
 import { Subscription } from 'rxjs';
@@ -12,13 +10,11 @@ import { LogHelper } from '@providers/logs/logs-helper';
 import { LogHelperMock } from '@providers/logs/__mocks__/logs-helper.mock';
 import { RouteByCategoryProvider } from '@providers/route-by-category/route-by-category';
 import { RouteByCategoryProviderMock } from '@providers/route-by-category/__mocks__/route-by-category.mock';
-import {
-  CAT_B, CAT_C, CAT_D, CAT_A_MOD1, CAT_A_MOD2, TestFlowPageNames,
-} from '@pages/page-names.constants';
+import { CAT_A_MOD1, CAT_A_MOD2, CAT_B, CAT_C, CAT_D, TestFlowPageNames } from '@pages/page-names.constants';
 import { StoreModel } from '@shared/models/store.model';
 import { DateTime, Duration } from '@shared/helpers/date-time';
 import { ActivityCodes } from '@shared/models/activity-codes';
-import { StartTest, ActivateTest } from '@store/tests/tests.actions';
+import { ActivateTest, StartTest } from '@store/tests/tests.actions';
 import { ContinueUnuploadedTest } from '@pages/unuploaded-tests/unuploaded-tests.actions';
 import { TestStatus } from '@store/tests/test-status/test-status.model';
 import { JournalModel } from '@store/journal/journal.model';
@@ -30,13 +26,14 @@ import { AccessibilityService } from '@providers/accessibility/accessibility.ser
 import { AccessibilityServiceMock } from '@providers/accessibility/__mocks__/accessibility-service.mock';
 import { TestOutcomeComponent } from '../test-outcome';
 import { TestSlotComponentsModule } from '../../test-slot-components.module';
+import { RouterMock } from '@mocks/angular-mocks/router-mock';
 
 describe('TestOutcomeComponent', () => {
   let fixture: ComponentFixture<TestOutcomeComponent>;
   let component: TestOutcomeComponent;
   let routeByCategory: RouteByCategoryProvider;
+  let router: Router;
   let store$: Store<StoreModel>;
-  const routerSpy = jasmine.createSpyObj('Router', ['navigateByUrl', 'navigate']);
 
   const testSlotDetail: SlotDetail = {
     duration: 57,
@@ -49,30 +46,90 @@ describe('TestOutcomeComponent', () => {
     lastRefreshed: new Date(),
     slots: {},
     selectedDate: 'dummy',
-    examiner: { staffNumber: '123', individualId: 456 },
+    examiner: {
+      staffNumber: '123',
+      individualId: 456,
+    },
     completedTests: [],
   };
 
   const categoryPages = [
-    { category: TestCategory.B, pageConstant: CAT_B },
-    { category: TestCategory.C, pageConstant: CAT_C },
-    { category: TestCategory.CE, pageConstant: CAT_C },
-    { category: TestCategory.C1, pageConstant: CAT_C },
-    { category: TestCategory.C1E, pageConstant: CAT_C },
-    { category: TestCategory.D, pageConstant: CAT_D },
-    { category: TestCategory.DE, pageConstant: CAT_D },
-    { category: TestCategory.D1, pageConstant: CAT_D },
-    { category: TestCategory.D1E, pageConstant: CAT_D },
-    { category: TestCategory.EUAM1, pageConstant: CAT_A_MOD1 },
-    { category: TestCategory.EUA2M1, pageConstant: CAT_A_MOD1 },
-    { category: TestCategory.EUAM1, pageConstant: CAT_A_MOD1 },
-    { category: TestCategory.EUAMM1, pageConstant: CAT_A_MOD1 },
-    { category: TestCategory.EUAM2, pageConstant: CAT_A_MOD2 },
-    { category: TestCategory.EUA2M2, pageConstant: CAT_A_MOD2 },
-    { category: TestCategory.EUAM2, pageConstant: CAT_A_MOD2 },
-    { category: TestCategory.EUAMM2, pageConstant: CAT_A_MOD2 },
-    { category: TestCategory.EUA1M1, pageConstant: CAT_A_MOD1 },
-    { category: TestCategory.EUA1M2, pageConstant: CAT_A_MOD2 },
+    {
+      category: TestCategory.B,
+      pageConstant: CAT_B,
+    },
+    {
+      category: TestCategory.C,
+      pageConstant: CAT_C,
+    },
+    {
+      category: TestCategory.CE,
+      pageConstant: CAT_C,
+    },
+    {
+      category: TestCategory.C1,
+      pageConstant: CAT_C,
+    },
+    {
+      category: TestCategory.C1E,
+      pageConstant: CAT_C,
+    },
+    {
+      category: TestCategory.D,
+      pageConstant: CAT_D,
+    },
+    {
+      category: TestCategory.DE,
+      pageConstant: CAT_D,
+    },
+    {
+      category: TestCategory.D1,
+      pageConstant: CAT_D,
+    },
+    {
+      category: TestCategory.D1E,
+      pageConstant: CAT_D,
+    },
+    {
+      category: TestCategory.EUAM1,
+      pageConstant: CAT_A_MOD1,
+    },
+    {
+      category: TestCategory.EUA2M1,
+      pageConstant: CAT_A_MOD1,
+    },
+    {
+      category: TestCategory.EUAM1,
+      pageConstant: CAT_A_MOD1,
+    },
+    {
+      category: TestCategory.EUAMM1,
+      pageConstant: CAT_A_MOD1,
+    },
+    {
+      category: TestCategory.EUAM2,
+      pageConstant: CAT_A_MOD2,
+    },
+    {
+      category: TestCategory.EUA2M2,
+      pageConstant: CAT_A_MOD2,
+    },
+    {
+      category: TestCategory.EUAM2,
+      pageConstant: CAT_A_MOD2,
+    },
+    {
+      category: TestCategory.EUAMM2,
+      pageConstant: CAT_A_MOD2,
+    },
+    {
+      category: TestCategory.EUA1M1,
+      pageConstant: CAT_A_MOD1,
+    },
+    {
+      category: TestCategory.EUA1M2,
+      pageConstant: CAT_A_MOD2,
+    },
   ];
 
   beforeEach(waitForAsync(() => {
@@ -98,10 +155,22 @@ describe('TestOutcomeComponent', () => {
         TestSlotComponentsModule,
       ],
       providers: [
-        { provide: LogHelper, useClass: LogHelperMock },
-        { provide: Router, useValue: routerSpy },
-        { provide: RouteByCategoryProvider, useClass: RouteByCategoryProviderMock },
-        { provide: AppComponent, useClass: MockAppComponent },
+        {
+          provide: LogHelper,
+          useClass: LogHelperMock,
+        },
+        {
+          provide: Router,
+          useClass: RouterMock,
+        },
+        {
+          provide: RouteByCategoryProvider,
+          useClass: RouteByCategoryProviderMock,
+        },
+        {
+          provide: AppComponent,
+          useClass: MockAppComponent,
+        },
         {
           provide: AccessibilityService,
           useClass: AccessibilityServiceMock,
@@ -114,8 +183,10 @@ describe('TestOutcomeComponent', () => {
     component = fixture.componentInstance;
     store$ = TestBed.inject(Store);
     routeByCategory = TestBed.inject(RouteByCategoryProvider);
+    router = TestBed.inject(Router);
     spyOn(store$, 'dispatch');
     spyOn(routeByCategory, 'navigateToPage');
+    spyOn(router, 'navigate');
   }));
 
   describe('Class', () => {
@@ -125,36 +196,43 @@ describe('TestOutcomeComponent', () => {
         component.category = TestCategory.B;
         component.startTest();
 
-        expect(store$.dispatch).toHaveBeenCalledWith(StartTest(component.slotDetail.slotId, component.category));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(StartTest(component.slotDetail.slotId, component.category));
       });
       it('should dispatch a start test action with the slot', () => {
         component.slotDetail = testSlotDetail;
         component.category = TestCategory.C;
         component.startTest();
 
-        expect(store$.dispatch).toHaveBeenCalledWith(StartTest(component.slotDetail.slotId, component.category));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(StartTest(component.slotDetail.slotId, component.category));
       });
     });
     describe('earlyStart', () => {
       it('should create and present the early start modal', () => {
         component.slotDetail = testSlotDetail;
-        component.slotDetail.start = new DateTime().add(8, Duration.MINUTE).format('YYYY-MM-DDTHH:mm:ss');
+        component.slotDetail.start = new DateTime().add(8, Duration.MINUTE)
+          .format('YYYY-MM-DDTHH:mm:ss');
         component.testStatus = TestStatus.Booked;
         spyOn(component, 'displayCheckStartModal');
         fixture.detectChanges();
         const startButton = fixture.debugElement.query(By.css('.mes-primary-button'));
         startButton.triggerEventHandler('click', null);
-        expect(component.displayCheckStartModal).toHaveBeenCalled();
+        expect(component.displayCheckStartModal)
+          .toHaveBeenCalled();
       });
       it('should not create and present the early start modal', () => {
         component.slotDetail = testSlotDetail;
-        component.slotDetail.start = new DateTime().add(2, Duration.MINUTE).format('YYYY-MM-DDTHH:mm:ss');
+        component.slotDetail.start = new DateTime().add(2, Duration.MINUTE)
+          .format('YYYY-MM-DDTHH:mm:ss');
         component.testStatus = TestStatus.Booked;
         spyOn(component, 'displayCheckStartModal');
         fixture.detectChanges();
         const startButton = fixture.debugElement.query(By.css('.mes-primary-button'));
         startButton.triggerEventHandler('click', null);
-        expect(component.displayCheckStartModal).not.toHaveBeenCalled();
+        expect(component.displayCheckStartModal)
+          .not
+          .toHaveBeenCalled();
       });
     });
 
@@ -166,16 +244,19 @@ describe('TestOutcomeComponent', () => {
       it('should dispatch the ContinueUnuploadedTest when hasNavigatedFromUnsubmitted is set to true', async () => {
         component.hasNavigatedFromUnsubmitted = true;
         await component.writeUpTest();
-        expect(store$.dispatch).toHaveBeenCalledWith(ContinueUnuploadedTest(TestStatus.WriteUp));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(ContinueUnuploadedTest(TestStatus.WriteUp));
       });
       categoryPages.forEach((cat) => {
         it(`should dispatch an ActivateTest action and navigate to the Office Cat ${cat.category} page`, async () => {
           component.category = cat.category;
           await component.writeUpTest();
-          expect(store$.dispatch).toHaveBeenCalledWith(ActivateTest(component.slotDetail.slotId, cat.category));
-          expect(routeByCategory.navigateToPage).toHaveBeenCalledWith(
-            TestFlowPageNames.OFFICE_PAGE, component.category, { state: { hasNavigatedFromUnsubmitted: false } },
-          );
+          expect(store$.dispatch)
+            .toHaveBeenCalledWith(ActivateTest(component.slotDetail.slotId, cat.category));
+          expect(routeByCategory.navigateToPage)
+            .toHaveBeenCalledWith(
+              TestFlowPageNames.OFFICE_PAGE, component.category, { state: { hasNavigatedFromUnsubmitted: false } },
+            );
         });
       });
     });
@@ -188,15 +269,18 @@ describe('TestOutcomeComponent', () => {
       it('should dispatch the ContinueUnuploadedTest when hasNavigatedFromUnsubmitted is set to true', async () => {
         component.hasNavigatedFromUnsubmitted = true;
         await component.resumeTest();
-        expect(store$.dispatch).toHaveBeenCalledWith(ContinueUnuploadedTest('Resume'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(ContinueUnuploadedTest('Resume'));
       });
       categoryPages.forEach((cat) => {
         it(`Cat ${cat.category} should dispatch an ActivateTest action and navigate to the Waiting Room page`, () => {
           component.testStatus = TestStatus.Started;
           component.category = cat.category;
           component.resumeTest();
-          expect(store$.dispatch).toHaveBeenCalledWith(ActivateTest(component.slotDetail.slotId, cat.category));
-          expect(routerSpy.navigate).toHaveBeenCalledWith([TestFlowPageNames.WAITING_ROOM_PAGE]);
+          expect(store$.dispatch)
+            .toHaveBeenCalledWith(ActivateTest(component.slotDetail.slotId, cat.category));
+          expect(router.navigate)
+            .toHaveBeenCalledWith([TestFlowPageNames.WAITING_ROOM_PAGE]);
         });
         it(`Cat ${cat.category} should dispatch an ActivateTest action and
          navigate to the Pass Finalisation page`, () => {
@@ -204,10 +288,12 @@ describe('TestOutcomeComponent', () => {
           component.activityCode = ActivityCodes.PASS;
           component.category = cat.category;
           component.resumeTest();
-          expect(store$.dispatch).toHaveBeenCalledWith(ActivateTest(component.slotDetail.slotId, cat.category));
-          expect(routeByCategory.navigateToPage).toHaveBeenCalledWith(
-            TestFlowPageNames.PASS_FINALISATION_PAGE, component.category,
-          );
+          expect(store$.dispatch)
+            .toHaveBeenCalledWith(ActivateTest(component.slotDetail.slotId, cat.category));
+          expect(routeByCategory.navigateToPage)
+            .toHaveBeenCalledWith(
+              TestFlowPageNames.PASS_FINALISATION_PAGE, component.category,
+            );
         });
         it(`Cat ${cat.category} should dispatch an ActivateTest action
         and navigate to the Non Pass Finalisation page`, () => {
@@ -215,10 +301,12 @@ describe('TestOutcomeComponent', () => {
           component.activityCode = ActivityCodes.FAIL;
           component.category = cat.category;
           component.resumeTest();
-          expect(store$.dispatch).toHaveBeenCalledWith(ActivateTest(component.slotDetail.slotId, cat.category));
-          expect(routeByCategory.navigateToPage).toHaveBeenCalledWith(
-            TestFlowPageNames.NON_PASS_FINALISATION_PAGE,
-          );
+          expect(store$.dispatch)
+            .toHaveBeenCalledWith(ActivateTest(component.slotDetail.slotId, cat.category));
+          expect(routeByCategory.navigateToPage)
+            .toHaveBeenCalledWith(
+              TestFlowPageNames.NON_PASS_FINALISATION_PAGE,
+            );
         });
       });
     });
@@ -230,7 +318,8 @@ describe('TestOutcomeComponent', () => {
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(false);
+        expect(component.showRekeyButton())
+          .toEqual(false);
       });
       it('should return true for a booked test on the rekey search page', () => {
         component.slotDetail = testSlotDetail;
@@ -239,7 +328,8 @@ describe('TestOutcomeComponent', () => {
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(true);
+        expect(component.showRekeyButton())
+          .toEqual(true);
       });
       it('should return false for a completed test on the rekey search page', () => {
         component.slotDetail = testSlotDetail;
@@ -248,17 +338,20 @@ describe('TestOutcomeComponent', () => {
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(false);
+        expect(component.showRekeyButton())
+          .toEqual(false);
       });
       it('should return true for a test that was started as a rekey and the date is in the past', () => {
         component.slotDetail = testSlotDetail;
-        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY).format('YYYY-MM-DDTHH:mm:ss');
+        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY)
+          .format('YYYY-MM-DDTHH:mm:ss');
         component.testStatus = TestStatus.Started;
         component.isRekey = true;
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(true);
+        expect(component.showRekeyButton())
+          .toEqual(true);
       });
       it('should return false for test that was started as a rekey and the date is today', () => {
         component.slotDetail = testSlotDetail;
@@ -268,43 +361,52 @@ describe('TestOutcomeComponent', () => {
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(false);
+        expect(component.showRekeyButton())
+          .toEqual(false);
       });
       it('should return true for a new test if date is in past', () => {
         component.slotDetail = testSlotDetail;
-        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY).format('YYYY-MM-DDTHH:mm:ss');
+        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY)
+          .format('YYYY-MM-DDTHH:mm:ss');
         component.testStatus = null;
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(true);
+        expect(component.showRekeyButton())
+          .toEqual(true);
       });
       it('should return true for a booked test if date is in past', () => {
         component.slotDetail = testSlotDetail;
-        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY).format('YYYY-MM-DDTHH:mm:ss');
+        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY)
+          .format('YYYY-MM-DDTHH:mm:ss');
         component.testStatus = TestStatus.Booked;
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(true);
+        expect(component.showRekeyButton())
+          .toEqual(true);
       });
       it('should return false for a resumed test if date is in past', () => {
         component.slotDetail = testSlotDetail;
-        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY).format('YYYY-MM-DDTHH:mm:ss');
+        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY)
+          .format('YYYY-MM-DDTHH:mm:ss');
         component.testStatus = TestStatus.Started;
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(false);
+        expect(component.showRekeyButton())
+          .toEqual(false);
       });
       it('should return true for a booked test if date is in the past', () => {
         component.slotDetail = testSlotDetail;
-        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY).format('YYYY-MM-DDTHH:mm:ss');
+        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY)
+          .format('YYYY-MM-DDTHH:mm:ss');
         component.testStatus = TestStatus.Booked;
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(true);
+        expect(component.showRekeyButton())
+          .toEqual(true);
       });
       it('should return false for a booked test if date is today', () => {
         component.slotDetail = testSlotDetail;
@@ -313,7 +415,8 @@ describe('TestOutcomeComponent', () => {
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(false);
+        expect(component.showRekeyButton())
+          .toEqual(false);
       });
       it('should return false for a resumed test if date is today', () => {
         component.slotDetail = testSlotDetail;
@@ -322,7 +425,8 @@ describe('TestOutcomeComponent', () => {
 
         component.showRekeyButton();
 
-        expect(component.showRekeyButton()).toEqual(false);
+        expect(component.showRekeyButton())
+          .toEqual(false);
       });
     });
   });
@@ -330,14 +434,17 @@ describe('TestOutcomeComponent', () => {
   describe('DOM', () => {
     describe('show start test button', () => {
       it('should show the start test button when the test status is Booked', () => {
-        spyOn(component, 'showRekeyButton').and.returnValue(false);
+        spyOn(component, 'showRekeyButton')
+          .and
+          .returnValue(false);
 
         component.slotDetail = testSlotDetail;
         component.testStatus = TestStatus.Booked;
         component.isDelegatedTest = false;
         fixture.detectChanges();
         const startButton = fixture.debugElement.queryAll(By.css('.mes-primary-button'));
-        expect(startButton.length).toBe(1);
+        expect(startButton.length)
+          .toBe(1);
       });
 
       it('should not show the start test button when the test has a status other than booked', () => {
@@ -345,13 +452,16 @@ describe('TestOutcomeComponent', () => {
         component.testStatus = TestStatus.Started;
         fixture.detectChanges();
         const startButton = fixture.debugElement.queryAll(By.css('.mes-primary-button'));
-        expect(startButton.length).toBe(0);
+        expect(startButton.length)
+          .toBe(0);
       });
     });
 
     describe('start a test', () => {
       it('should call the startTest method when `Start test` is clicked', () => {
-        spyOn(component, 'showRekeyButton').and.returnValue(false);
+        spyOn(component, 'showRekeyButton')
+          .and
+          .returnValue(false);
 
         component.slotDetail = testSlotDetail;
         component.testStatus = TestStatus.Booked;
@@ -362,7 +472,8 @@ describe('TestOutcomeComponent', () => {
         const startButton = fixture.debugElement.query(By.css('.mes-primary-button'));
         startButton?.triggerEventHandler('click', null);
 
-        expect(component.startTest).toHaveBeenCalled();
+        expect(component.startTest)
+          .toHaveBeenCalled();
       });
     });
 
@@ -374,25 +485,29 @@ describe('TestOutcomeComponent', () => {
       it('should dispatch the ContinueUnuploadedTest when hasNavigatedFromUnsubmitted is set to true', async () => {
         component.hasNavigatedFromUnsubmitted = true;
         await component.rekeyTest();
-        expect(store$.dispatch).toHaveBeenCalledWith(ContinueUnuploadedTest('Rekey'));
+        expect(store$.dispatch)
+          .toHaveBeenCalledWith(ContinueUnuploadedTest('Rekey'));
       });
       it('should call the rekeyTest method when `Rekey` is clicked', () => {
         component.slotDetail = testSlotDetail;
         component.category = TestCategory.B;
         component.testStatus = TestStatus.Booked;
-        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY).format('YYYY-MM-DDTHH:mm:ss');
+        component.slotDetail.start = new DateTime().subtract(1, Duration.DAY)
+          .format('YYYY-MM-DDTHH:mm:ss');
         fixture.detectChanges();
         spyOn(component, 'rekeyTest');
         const rekeyButton = fixture.debugElement.query(By.css('.mes-rekey-button'));
         rekeyButton.triggerEventHandler('click', null);
-        expect(component.rekeyTest).toHaveBeenCalled();
+        expect(component.rekeyTest)
+          .toHaveBeenCalled();
       });
       categoryPages.forEach((cat) => {
         it(`should navigate to cat ${cat.category} waiting room page when "Rekey" is clicked`, () => {
           component.slotDetail = testSlotDetail;
           component.category = cat.category;
           component.rekeyTest();
-          expect(routerSpy.navigate).toHaveBeenCalledWith([TestFlowPageNames.WAITING_ROOM_PAGE]);
+          expect(router.navigate)
+            .toHaveBeenCalledWith([TestFlowPageNames.WAITING_ROOM_PAGE]);
         });
       });
     });
@@ -401,18 +516,23 @@ describe('TestOutcomeComponent', () => {
       it('should call the rekeyDelegatedTest method when `Rekey` is clicked', () => {
         component.slotDetail = testSlotDetail;
         component.category = TestCategory.BE;
-        spyOn(component, 'showDelegatedExaminerRekeyButton').and.returnValue(true);
+        spyOn(component, 'showDelegatedExaminerRekeyButton')
+          .and
+          .returnValue(true);
         spyOn(component, 'rekeyDelegatedTest');
         fixture.detectChanges();
         const rekeyDelegatedButton = fixture.debugElement.query(By.css('.mes-rekey-button'));
         rekeyDelegatedButton.triggerEventHandler('click', null);
-        expect(component.rekeyDelegatedTest).toHaveBeenCalled();
+        expect(component.rekeyDelegatedTest)
+          .toHaveBeenCalled();
       });
     });
 
     describe('debrief a test', () => {
       it('should call the resumeTest method when `Resume` is clicked', () => {
-        spyOn(component, 'showResumeButton').and.returnValue(true);
+        spyOn(component, 'showResumeButton')
+          .and
+          .returnValue(true);
         component.slotDetail = testSlotDetail;
         component.testStatus = TestStatus.Decided;
         fixture.detectChanges();
@@ -421,7 +541,8 @@ describe('TestOutcomeComponent', () => {
         const debriefButton = fixture.debugElement.query(By.css('.mes-warning-button'));
         debriefButton.triggerEventHandler('click', null);
 
-        expect(component.resumeTest).toHaveBeenCalled();
+        expect(component.resumeTest)
+          .toHaveBeenCalled();
       });
     });
 
@@ -435,13 +556,16 @@ describe('TestOutcomeComponent', () => {
         const writeUpButton = fixture.debugElement.query(By.css('.mes-secondary-button'));
         writeUpButton.triggerEventHandler('click', null);
 
-        expect(component.writeUpTest).toHaveBeenCalled();
+        expect(component.writeUpTest)
+          .toHaveBeenCalled();
       });
     });
 
     describe('resume a test', () => {
       it('should call the resumeTest method when `Resume` is clicked', () => {
-        spyOn(component, 'showResumeButton').and.returnValue(true);
+        spyOn(component, 'showResumeButton')
+          .and
+          .returnValue(true);
         component.slotDetail = testSlotDetail;
         component.testStatus = TestStatus.Started;
         fixture.detectChanges();
@@ -450,26 +574,34 @@ describe('TestOutcomeComponent', () => {
         const resumeButton = fixture.debugElement.query(By.css('.mes-warning-button'));
         resumeButton.triggerEventHandler('click', null);
 
-        expect(component.resumeTest).toHaveBeenCalled();
+        expect(component.resumeTest)
+          .toHaveBeenCalled();
       });
     });
 
     describe('rekey button', () => {
       it('should show rekey button', () => {
-        spyOn(component, 'showRekeyButton').and.returnValue(true);
+        spyOn(component, 'showRekeyButton')
+          .and
+          .returnValue(true);
         fixture.detectChanges();
 
         const rekeyButton = fixture.debugElement.query(By.css('.mes-rekey-button'));
 
-        expect(rekeyButton).not.toBeNull();
+        expect(rekeyButton)
+          .not
+          .toBeNull();
       });
       it('should hide rekey button', () => {
-        spyOn(component, 'showRekeyButton').and.returnValue(false);
+        spyOn(component, 'showRekeyButton')
+          .and
+          .returnValue(false);
         fixture.detectChanges();
 
         const rekeyButton = fixture.debugElement.query(By.css('.mes-rekey-button'));
 
-        expect(rekeyButton).toBeNull();
+        expect(rekeyButton)
+          .toBeNull();
       });
     });
 
@@ -480,20 +612,25 @@ describe('TestOutcomeComponent', () => {
           component.testStatus = TestStatus.Submitted;
           fixture.detectChanges();
           const outcomeCode = fixture.debugElement.query(By.css('.outcome'));
-          expect(outcomeCode).not.toBeNull();
+          expect(outcomeCode)
+            .not
+            .toBeNull();
         });
         it('should hide the activity code if none available', () => {
           component.slotDetail = testSlotDetail;
           component.slotDetail.slotId = null;
           fixture.detectChanges();
           const outcomeCode = fixture.debugElement.query(By.css('.outcome'));
-          expect(outcomeCode).toBeNull();
+          expect(outcomeCode)
+            .toBeNull();
         });
       });
 
       describe('show force detail check modal', () => {
         it('should display the force detail check modal', () => {
-          spyOn(component, 'showRekeyButton').and.returnValue(false);
+          spyOn(component, 'showRekeyButton')
+            .and
+            .returnValue(false);
 
           component.specialRequirements = true;
           component.slotDetail = testSlotDetail;
@@ -505,13 +642,16 @@ describe('TestOutcomeComponent', () => {
           const startButton = fixture.debugElement.query(By.css('.mes-primary-button'));
           startButton?.triggerEventHandler('click', null);
 
-          expect(component.displayForceCheckModal).toHaveBeenCalled();
+          expect(component.displayForceCheckModal)
+            .toHaveBeenCalled();
         });
       });
 
       describe('candidate details seen, force detail check modal should not be seen', () => {
         it('should not display the force detail check modal', () => {
-          spyOn(component, 'showRekeyButton').and.returnValue(false);
+          spyOn(component, 'showRekeyButton')
+            .and
+            .returnValue(false);
 
           component.specialRequirements = true;
           component.slotDetail = testSlotDetail;
@@ -524,7 +664,8 @@ describe('TestOutcomeComponent', () => {
           const startButton = fixture.debugElement.query(By.css('.mes-primary-button'));
           startButton?.triggerEventHandler('click', null);
 
-          expect(component.displayForceCheckModal).toHaveBeenCalledTimes(0);
+          expect(component.displayForceCheckModal)
+            .toHaveBeenCalledTimes(0);
         });
       });
     });


### PR DESCRIPTION
## Description
- Move device locking and unlocking to base page
- Remove uses of `routerSpy` in favour of `RouterMock` class
- Update Sentry Error handler to use new auth method which should rebind the value of the employee ID to the service

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
