### PR TITLE
Mes 9025 office fault header fix

### DIFF
--- a/src/app/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
+++ b/src/app/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
@@ -153,6 +153,7 @@
             <fault-comment-card
                     id="driving-fault-comment-card"
                     faultType="driving"
+                    header="Riding"
                     badgeLabel="Riding"
                     [formGroup]="form"
                     [faultComments]="pageState.drivingFaults$ | async"

--- a/src/app/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
+++ b/src/app/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
@@ -9,7 +9,7 @@ import { FaultSummary } from '@shared/models/fault-marking.model';
 import { FaultCommentComponent } from '../../fault-comment/fault-comment';
 import { FaultCommentCardComponent } from '../fault-comment-card';
 
-fdescribe('FaultCommentCardComponent', () => {
+describe('FaultCommentCardComponent', () => {
   let fixture: ComponentFixture<FaultCommentCardComponent>;
   let component: FaultCommentCardComponent;
 

--- a/src/app/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
+++ b/src/app/pages/office/components/fault-comment-card/__tests__/fault-comment-card.spec.ts
@@ -9,7 +9,7 @@ import { FaultSummary } from '@shared/models/fault-marking.model';
 import { FaultCommentComponent } from '../../fault-comment/fault-comment';
 import { FaultCommentCardComponent } from '../fault-comment-card';
 
-describe('FaultCommentCardComponent', () => {
+fdescribe('FaultCommentCardComponent', () => {
   let fixture: ComponentFixture<FaultCommentCardComponent>;
   let component: FaultCommentCardComponent;
 
@@ -41,7 +41,7 @@ describe('FaultCommentCardComponent', () => {
       fixture.detectChanges();
 
       const header = fixture.debugElement.query(By.css('h2')).nativeElement;
-      expect(header.innerHTML).toBe('header');
+      expect(header.innerHTML).toBe(' header  ');
     });
 
     it('should pass the faultComment and type to the fault-comment component', () => {

--- a/src/app/pages/office/components/fault-comment-card/fault-comment-card.html
+++ b/src/app/pages/office/components/fault-comment-card/fault-comment-card.html
@@ -1,7 +1,9 @@
 <div [hidden]="!shouldRender">
     <ion-card [formGroup]="formGroup">
         <ion-card-header>
-            <h2 class="des-header-style-4" [id]="header | formatToID: idPrefix">{{header}}</h2>
+            <h2 class="des-header-style-4" [id]="header | formatToID: idPrefix">
+              {{header}} {{faultType === 'driving' ? faultCount > 1 ? ' faults' : ' fault' : ''}}
+            </h2>
         </ion-card-header>
         <ion-card-content>
             <ion-row class="mes-validated-row mes-row-separator" *ngFor="let faultComment of faultComments; trackBy: trackByIndex">


### PR DESCRIPTION
## Description
Fixed issue where fault headers on office page were incorrectly displaying fault/faults and aria wasn't reading correct label
## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
