### PR TITLE
MES-8938 | Provisional Licence not received bug fix

### DIFF
--- a/src/app/pages/confirm-test-details/confirm-test-details.page.ts
+++ b/src/app/pages/confirm-test-details/confirm-test-details.page.ts
@@ -200,7 +200,6 @@ export class ConfirmTestDetailsPage
         map(([testResult]) => testResult),
         select(getPassCompletion),
         map(isProvisionalLicenseProvided),
-        take(1),
       ),
       // ADI3 & SC additional fields
       testOutcomeFullResult$: currentTest$.pipe(


### PR DESCRIPTION
## Description
Removed usage of take(1) on provisionalLicence$ observable as it was causing the incorrect value to be used on confirm-test-details page
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
