### PR TITLE
mes-9770-release-journalRecoveredBannerDisplayFix

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,7 +6,7 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: Missing Release of Resource after Effective Lifetime - Remediation not yet available
-        expires: 2024-06-01T09:00:00.119Z
+        expires: 2024-07-01T09:00:00.119Z
         created: 2023-12-04T09:00:00.122Z
   SNYK-JS-MICROMATCH-6838728:
     - '*':

--- a/src/app/pages/journal/components/journal-slot/__tests__/journal-slot.spec.ts
+++ b/src/app/pages/journal/components/journal-slot/__tests__/journal-slot.spec.ts
@@ -6,7 +6,7 @@ import { SlotSelectorProvider } from '@providers/slot-selector/slot-selector';
 import { SlotSelectorProviderMock } from '@providers/slot-selector/__mocks__/slot-selector.mock';
 import { SlotItem } from '@providers/slot-selector/slot-item';
 import { TestSlot } from '@dvsa/mes-journal-schema';
-import { SearchResultTestSchema } from '@dvsa/mes-search-schema';
+import { CompletedJournalSlot } from '@pages/journal/journal.page';
 
 describe('JournalSlotComponent', () => {
   let fixture: ComponentFixture<JournalSlotComponent>;
@@ -86,7 +86,7 @@ describe('JournalSlotComponent', () => {
           },
         },
       } as TestSlot;
-      component.completedTests = [{ applicationReference: 9999 }] as SearchResultTestSchema[];
+      component.completedTests = [{ applicationReference: 9999 }] as CompletedJournalSlot[];
       expect(component.findCompletedTest(slotData)).toBeUndefined();
     });
 
@@ -100,7 +100,7 @@ describe('JournalSlotComponent', () => {
           },
         },
       } as TestSlot;
-      const completedTest = { applicationReference: 1023 } as SearchResultTestSchema;
+      const completedTest = { applicationReference: 1023 } as CompletedJournalSlot;
       component.completedTests = [completedTest];
       expect(component.findCompletedTest(slotData)).toEqual(completedTest);
     });

--- a/src/app/pages/journal/components/journal-slot/journal-slot.ts
+++ b/src/app/pages/journal/components/journal-slot/journal-slot.ts
@@ -6,6 +6,7 @@ import { SlotItem } from '@providers/slot-selector/slot-item';
 import { SlotSelectorProvider } from '@providers/slot-selector/slot-selector';
 import { ApplicationReference } from '@dvsa/mes-test-schema/categories/common';
 import { formatApplicationReference } from '@shared/helpers/formatters';
+import { CompletedJournalSlot } from '@pages/journal/journal.page';
 
 
 
@@ -16,7 +17,7 @@ import { formatApplicationReference } from '@shared/helpers/formatters';
 export class JournalSlotComponent {
 
   @Input()
-  completedTests: SearchResultTestSchema[] = [];
+  completedTests: CompletedJournalSlot[] = [];
 
   @Input()
   slots: SlotItem[] = [];
@@ -36,7 +37,7 @@ export class JournalSlotComponent {
    * Find the completed test for the given slot if exists
    * @param slotData
    */
-  findCompletedTest(slotData: TestSlot): SearchResultTestSchema | null {
+  findCompletedTest(slotData: TestSlot): CompletedJournalSlot {
     if (!!get(slotData, 'booking')) {
       const tempAppRef = parseInt(formatApplicationReference({
         applicationId: slotData.booking.application.applicationId,

--- a/src/app/pages/journal/journal.page.ts
+++ b/src/app/pages/journal/journal.page.ts
@@ -273,7 +273,7 @@ export class JournalPage extends BasePageComponent implements OnInit {
    * @param testSlots
    */
   formatCompleteTests(completedTests: SearchResultTestSchema[], testSlots: SlotItem[]): CompletedJournalSlot[] {
-    let arrayOfTests = testSlots.map((slot: SlotItem) => {
+    let arrayOfTests: number[] = testSlots.map((slot: SlotItem) => {
       if (get(slot, 'slotData.booking')) {
         return parseInt(formatApplicationReference({
           applicationId: (slot.slotData as TestSlot).booking.application.applicationId,
@@ -283,13 +283,13 @@ export class JournalPage extends BasePageComponent implements OnInit {
       }
     })
 
-    let matchingTests = arrayOfTests
+    let matchingTests: number[] = arrayOfTests
       .filter(element => completedTests
         .map(value => value.applicationReference).includes(element));
 
     return completedTests
-      .filter(value => matchingTests.includes(value.applicationReference))
-      .map((value): CompletedJournalSlot => {
+      .filter((value: SearchResultTestSchema) => matchingTests.includes(value.applicationReference))
+      .map((value: SearchResultTestSchema): CompletedJournalSlot => {
         return {
           applicationReference: value.applicationReference,
           activityCode: value.activityCode,

--- a/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
+++ b/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
@@ -317,56 +317,51 @@ describe('TestSlotComponent', () => {
 
     describe('isAutosavedTest', () => {
       it('should return true when remoteAutosaved is 1 and testStatus is not Autosaved', () => {
-        const result = component.isAutosavedTest(1, TestStatus.Completed);
+        const result = component.isAutosavedTest(true, TestStatus.Completed);
         expect(result).toEqual(true);
       });
 
       it('should return false when remoteAutosaved is 1 and testStatus is Autosaved', () => {
-        const result = component.isAutosavedTest(1, TestStatus.Autosaved);
+        const result = component.isAutosavedTest(true, TestStatus.Autosaved);
         expect(result).toEqual(false);
       });
 
       it('should return false when remoteAutosaved is 0 and testStatus is Autosaved', () => {
-        const resultWithAutosavedStatus = component.isAutosavedTest(0, TestStatus.Autosaved);
+        const resultWithAutosavedStatus = component.isAutosavedTest(false, TestStatus.Autosaved);
         expect(resultWithAutosavedStatus).toEqual(false);
       });
 
       it('should return false when remoteAutosaved is 0 and testStatus is not Autosaved', () => {
-        const resultWithCompletedStatus = component.isAutosavedTest(0, TestStatus.Completed);
+        const resultWithCompletedStatus = component.isAutosavedTest(false, TestStatus.Completed);
         expect(resultWithCompletedStatus).toEqual(false);
       });
     });
 
     describe('showRecoveredBanner', () => {
-      it('should return true when remoteAutosaved is 1 and ' +
+      it('should return false when isRehydrated is true and ' +
         'testStatus is not Autosaved or Completed or Submitted', () => {
-        const result = component.showRecoveredBanner(1, TestStatus.Started);
+        const result = component.showRecoveredBanner(true, TestStatus.Started);
+        expect(result).toEqual(false);
+      });
+
+      it('should return true when isRehydrated is true and testStatus is Autosaved', () => {
+        const result = component.showRecoveredBanner(true, TestStatus.Autosaved);
         expect(result).toEqual(true);
       });
 
-      it('should return false when remoteAutosaved is 1 and testStatus is Autosaved', () => {
-        const result = component.showRecoveredBanner(1, TestStatus.Autosaved);
-        expect(result).toEqual(false);
+      it('should return true when isRehydrated is true and testStatus is Completed', () => {
+        const result = component.showRecoveredBanner(true, TestStatus.Completed);
+        expect(result).toEqual(true);
       });
 
-      it('should return false when remoteAutosaved is 1 and testStatus is Completed', () => {
-        const result = component.showRecoveredBanner(1, TestStatus.Completed);
-        expect(result).toEqual(false);
+      it('should return true when isRehydrated is true and testStatus is Submitted', () => {
+        const result = component.showRecoveredBanner(true, TestStatus.Submitted);
+        expect(result).toEqual(true);
       });
 
-      it('should return false when remoteAutosaved is 1 and testStatus is Submitted', () => {
-        const result = component.showRecoveredBanner(1, TestStatus.Submitted);
-        expect(result).toEqual(false);
-      });
-
-      it('should return false when remoteAutosaved is 0 and testStatus is Autosaved', () => {
-        const resultWithAutosavedStatus = component.showRecoveredBanner(0, TestStatus.Autosaved);
+      it('should return false when isRehydrated is false', () => {
+        const resultWithAutosavedStatus = component.showRecoveredBanner(false, TestStatus.Autosaved);
         expect(resultWithAutosavedStatus).toEqual(false);
-      });
-
-      it('should return false when remoteAutosaved is 0 and testStatus is not Autosaved', () => {
-        const resultWithCompletedStatus = component.showRecoveredBanner(0, TestStatus.Completed);
-        expect(resultWithCompletedStatus).toEqual(false);
       });
     });
 
@@ -422,6 +417,7 @@ describe('TestSlotComponent', () => {
             testActivityCode$: of(ActivityCodes.PASS),
             testPassCertificate$: of('C123456X'),
             isRekey$: of(false),
+            isRehydrated$: of(false)
           };
           fixture.detectChanges();
           const subByDirective = fixture.debugElement.query(

--- a/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
+++ b/src/components/test-slot/test-slot/__tests__/test-slot.spec.ts
@@ -337,6 +337,39 @@ describe('TestSlotComponent', () => {
       });
     });
 
+    describe('showRecoveredBanner', () => {
+      it('should return true when remoteAutosaved is 1 and ' +
+        'testStatus is not Autosaved or Completed or Submitted', () => {
+        const result = component.showRecoveredBanner(1, TestStatus.Started);
+        expect(result).toEqual(true);
+      });
+
+      it('should return false when remoteAutosaved is 1 and testStatus is Autosaved', () => {
+        const result = component.showRecoveredBanner(1, TestStatus.Autosaved);
+        expect(result).toEqual(false);
+      });
+
+      it('should return false when remoteAutosaved is 1 and testStatus is Completed', () => {
+        const result = component.showRecoveredBanner(1, TestStatus.Completed);
+        expect(result).toEqual(false);
+      });
+
+      it('should return false when remoteAutosaved is 1 and testStatus is Submitted', () => {
+        const result = component.showRecoveredBanner(1, TestStatus.Submitted);
+        expect(result).toEqual(false);
+      });
+
+      it('should return false when remoteAutosaved is 0 and testStatus is Autosaved', () => {
+        const resultWithAutosavedStatus = component.showRecoveredBanner(0, TestStatus.Autosaved);
+        expect(resultWithAutosavedStatus).toEqual(false);
+      });
+
+      it('should return false when remoteAutosaved is 0 and testStatus is not Autosaved', () => {
+        const resultWithCompletedStatus = component.showRecoveredBanner(0, TestStatus.Completed);
+        expect(resultWithCompletedStatus).toEqual(false);
+      });
+    });
+
     describe('DOM', () => {
       describe('Component Interaction', () => {
         it('should pass the special needs status to a indicator component', () => {

--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -32,7 +32,7 @@
             >
             </integrity-marker>
             <autosave-status
-              *ngIf="!isTeamJournal && isAutosavedTest(completedTestRecord?.autosave, componentState.testStatus$ | async)"
+              *ngIf="!isTeamJournal && showRecoveredBanner(completedTestRecord?.autosave, componentState.testStatus$ | async)"
               class="full-width"
             >
             </autosave-status>

--- a/src/components/test-slot/test-slot/test-slot.html
+++ b/src/components/test-slot/test-slot/test-slot.html
@@ -27,12 +27,13 @@
             <integrity-marker
               *ngIf="slot.booking.application.fitMarker &&
               !isCompletedTest(componentState.testStatus$ | async) &&
-              !isAutosavedTest(completedTestRecord?.autosave, componentState.testStatus$ | async)"
+              !isAutosavedTest(completedTestRecord?.autosave, componentState.testStatus$ | async) &&
+              !(!isTeamJournal && showRecoveredBanner(componentState.isRehydrated$ | async, componentState.testStatus$ | async))"
               class="full-width"
             >
             </integrity-marker>
             <autosave-status
-              *ngIf="!isTeamJournal && showRecoveredBanner(completedTestRecord?.autosave, componentState.testStatus$ | async)"
+              *ngIf="!isTeamJournal && showRecoveredBanner(componentState.isRehydrated$ | async, componentState.testStatus$ | async)"
               class="full-width"
             >
             </autosave-status>

--- a/src/components/test-slot/test-slot/test-slot.ts
+++ b/src/components/test-slot/test-slot/test-slot.ts
@@ -203,6 +203,10 @@ export class TestSlotComponent implements SlotComponent, OnInit {
     return Boolean(remoteAutosaved) && testStatus !== TestStatus.Autosaved;
   }
 
+  /**
+   * Returns true if the test is autosaved, completed or submitted, we need to use a new function as
+   * integrity-marker needs to display on a submitted test.
+   */
   showRecoveredBanner = (remoteAutosaved: number, testStatus: TestStatus): boolean => {
     return Boolean(remoteAutosaved) &&
       !isAnyOf(testStatus, [

--- a/src/components/test-slot/test-slot/test-slot.ts
+++ b/src/components/test-slot/test-slot/test-slot.ts
@@ -203,6 +203,15 @@ export class TestSlotComponent implements SlotComponent, OnInit {
     return Boolean(remoteAutosaved) && testStatus !== TestStatus.Autosaved;
   }
 
+  showRecoveredBanner = (remoteAutosaved: number, testStatus: TestStatus): boolean => {
+    return Boolean(remoteAutosaved) &&
+      !isAnyOf(testStatus, [
+        TestStatus.Autosaved,
+        TestStatus.Completed,
+        TestStatus.Submitted
+      ]) ;
+  }
+
   showOutcome(status: TestStatus): boolean {
     return [TestStatus.Completed, TestStatus.Submitted].includes(status);
   }


### PR DESCRIPTION
## Description
Fixed an issue where the recovered banner would show up despite the test being completed on the device

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
