### PR TITLE
MES-9748 | ADI TR Event Name change

### DIFF
--- a/src/app/pages/test-report/test-report.analytics.effects.ts
+++ b/src/app/pages/test-report/test-report.analytics.effects.ts
@@ -3175,8 +3175,8 @@ export class TestReportAnalyticsEffects {
       );
       // GA4 Analytics
       this.analytics.logGAEvent(
-        analyticsEventTypePrefix(GoogleAnalyticsEvents.LESSON_PLANNING, tests),
-        `${GoogleAnalyticsEventsTitles.QUESTION_NUMBER}_Q${question}`,
+        analyticsEventTypePrefix(`${GoogleAnalyticsEvents.LESSON_PLANNING}_Q${question}`, tests),
+        GoogleAnalyticsEventsTitles.QUESTION_SCORE,
         String(score),
       );
       return of(AnalyticRecorded());
@@ -3215,8 +3215,8 @@ export class TestReportAnalyticsEffects {
       );
       // GA4 Analytics
       this.analytics.logGAEvent(
-        analyticsEventTypePrefix(GoogleAnalyticsEvents.RISK_MANAGEMENT, tests),
-        `${GoogleAnalyticsEventsTitles.QUESTION_NUMBER}_Q${question}`,
+        analyticsEventTypePrefix(`${GoogleAnalyticsEvents.RISK_MANAGEMENT}_Q${question}`, tests),
+        GoogleAnalyticsEventsTitles.QUESTION_SCORE,
         String(score),
       );
       return of(AnalyticRecorded());
@@ -3255,8 +3255,8 @@ export class TestReportAnalyticsEffects {
       );
       // GA4 analytics
       this.analytics.logGAEvent(
-        analyticsEventTypePrefix(GoogleAnalyticsEvents.LEARNING_STRATEGY, tests),
-        `${GoogleAnalyticsEventsTitles.QUESTION_NUMBER}_Q${question}`,
+        analyticsEventTypePrefix(`${GoogleAnalyticsEvents.LEARNING_STRATEGY}_Q${question}`, tests),
+        GoogleAnalyticsEventsTitles.QUESTION_SCORE,
         String(score),
       );
       return of(AnalyticRecorded());


### PR DESCRIPTION
## Description
Changed ADI & SC question events to include question number in event name & changed title used to QUESTION_SCORE instead of QUESTION_NUMBER

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
