### PR TITLE
mes-9908-practiceModeBannerClipping

### DIFF
--- a/src/components/common/practice-mode-banner/practice-mode-banner.html
+++ b/src/components/common/practice-mode-banner/practice-mode-banner.html
@@ -1,5 +1,6 @@
 <ion-toolbar class="practice-mode-toolbar-sizing">
-  <ion-row class="practice-mode-top-banner">
+  <ion-row class="practice-mode-top-banner"></ion-row>
+  <ion-row class="practice-mode-banner-text">
     <ion-col size="1" class="practice-exit-icon ion-no-padding" (click)="exitPracticeMode()">
       <ion-icon aria-hidden="true" id="practice-mode-exit" name="caret-back"></ion-icon>
     </ion-col>

--- a/src/components/common/practice-mode-banner/practice-mode-banner.scss
+++ b/src/components/common/practice-mode-banner/practice-mode-banner.scss
@@ -1,18 +1,30 @@
-.practice-mode-top-banner {
-  background: var(--gds-yellow);
+.practice-mode-base {
   border-radius: 0;
-  font-size: 18px;
-  font-weight: bold;
-  color: var(--gds-black);
-  height: 36px;
   padding-bottom: 0;
   padding-top: 0;
   width: 110%;
   margin-left: -5px;
 }
 
+.practice-mode-top-banner {
+  @extend .practice-mode-base;
+  position: fixed;
+  background: var(--gds-yellow);
+  height: 20px;
+}
+
+.practice-mode-banner-text {
+  @extend .practice-mode-base;
+  font-size: 18px;
+  font-weight: bold;
+  color: var(--gds-black);
+  height: 36px;
+  position: relative;
+  bottom: 3pt;
+}
+
 .practice-mode-toolbar-sizing {
-  padding-top: 12px;
+  padding-top: 15px;
   padding-bottom: 0;
   height: 40px;
 }


### PR DESCRIPTION
## Description
Made the practice mode banner smaller so it no longer overlaps with the toolbar at the top of the ipad
## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
10th gen
![image](https://github.com/user-attachments/assets/ca998397-407b-4545-a77f-909ca09da803)
9th gen
![image](https://github.com/user-attachments/assets/d5f60524-a78a-40a9-a7b1-fa9b8e05c20a)
