### PR TITLE
mes-9911-backButtonManeouvresReturnsToWrongPage

### DIFF
--- a/src/app/pages/waiting-room-to-car/cat-manoeuvre/__tests__/waiting-room-to-car.cat-manoeuvre.page.spec.ts
+++ b/src/app/pages/waiting-room-to-car/cat-manoeuvre/__tests__/waiting-room-to-car.cat-manoeuvre.page.spec.ts
@@ -150,7 +150,7 @@ describe('WaitingRoomToCarCatManoeuvrePage', () => {
         expect(routeByCategoryProvider.navigateToPage).toHaveBeenCalledWith(
           TestFlowPageNames.TEST_REPORT_PAGE,
           TestCategory.CM,
-          { replaceUrl: true }
+          { replaceUrl: false }
         );
       }));
       it('should dispatch the appropriate WaitingRoomToCarValidationError actions', fakeAsync(async () => {

--- a/src/app/pages/waiting-room-to-car/cat-manoeuvre/waiting-room-to-car.cat-manoeuvre.page.ts
+++ b/src/app/pages/waiting-room-to-car/cat-manoeuvre/waiting-room-to-car.cat-manoeuvre.page.ts
@@ -69,7 +69,7 @@ export class WaitingRoomToCarCatManoeuvrePage extends WaitingRoomToCarBasePageCo
       this.store$.dispatch(ClearCandidateLicenceData());
 
       await this.routeByCategoryProvider.navigateToPage(TestFlowPageNames.TEST_REPORT_PAGE, this.testCategory, {
-        replaceUrl: true,
+        replaceUrl: false,
       });
       return;
     }


### PR DESCRIPTION
## Description
Fixed routing issue where pressing the back button on a test report for a manoeuvre category would take you to the wrong page
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
