### PR TITLE
mes-9746-eyesightTestFail

### DIFF
--- a/src/app/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
+++ b/src/app/pages/waiting-room-to-car/components/eyesight-failure-confirmation/eyesight-failure-confirmation.ts
@@ -27,7 +27,7 @@ export class EyesightFailureConfirmationComponent {
   }
 
   async onContinue(): Promise<void> {
-    await this.router.navigate([this.nextPageOnFail]);
     this.store$.dispatch(SetActivityCode(ActivityCodes.FAIL_EYESIGHT));
+    await this.router.navigate([this.nextPageOnFail]);
   }
 }


### PR DESCRIPTION
Fixed a bug where an eyesight fail would display as terminated on the debrief page

## Description

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
