### PR TITLE
mes-9970-examinerRecordsBrokenDateFilter

### DIFF
--- a/src/app/pages/examiner-records/examiner-records.page.ts
+++ b/src/app/pages/examiner-records/examiner-records.page.ts
@@ -120,7 +120,6 @@ export class ExaminerRecordsPage implements OnInit {
   cachedExaminerRecords: ExaminerRecordModel[] = null;
   startDateFilter: string;
   endDateFilter: string = new DateTime().format('DD/MM/YYYY');
-  scrollValue = 0;
   isLoading = false;
 
   public defaultDate: SelectableDateRange = this.examinerRecordsProvider.localFilterOptions[2];

--- a/src/app/pages/examiner-records/examiner-records.selector.ts
+++ b/src/app/pages/examiner-records/examiner-records.selector.ts
@@ -42,7 +42,7 @@ const unwantedCategories: TestCategory[] = [
 export const dateFilter = (test: ExaminerRecordModel, range: DateRange = null): boolean =>
   range
     ? // use range when provided
-      new DateTime(get(test, 'startDate')).isDuring(range)
+      new DateTime(get(test, 'startDate')).isDuring(range, true)
     : // return true to get all tests when no range provided
       true;
 

--- a/src/app/providers/examiner-records/__tests__/examiner-records.spec.ts
+++ b/src/app/providers/examiner-records/__tests__/examiner-records.spec.ts
@@ -69,12 +69,12 @@ describe('ExaminerRecordsProvider', () => {
   });
 
   describe('formatForExaminerRecords', () => {
-    it('should an object containing the mandatory fields', () => {
+    it('should return an object containing the mandatory fields', () => {
       expect(
         provider.formatForExaminerRecords({
           journalData: {
             testSlotAttributes: {
-              start: 'Text Date',
+              start: '2000-01-01',
             } as TestSlotAttributes,
             applicationReference: {
               applicationId: 1,
@@ -97,16 +97,16 @@ describe('ExaminerRecordsProvider', () => {
           costCode: 'EXPLE',
           centreName: 'Example',
         },
-        startDate: 'Text Date',
+        startDate: '2000-01-01',
       });
     });
-    it('should an object containing an optional field contained within the for loop', () => {
+    it('should return an object containing an optional field contained within the for loop', () => {
       expect(
         provider.formatForExaminerRecords({
           testData: { controlledStop: { selected: true } },
           journalData: {
             testSlotAttributes: {
-              start: 'Text Date',
+              start: '2000-01-01',
             } as TestSlotAttributes,
             applicationReference: {
               applicationId: 1,
@@ -130,16 +130,16 @@ describe('ExaminerRecordsProvider', () => {
           costCode: 'EXPLE',
           centreName: 'Example',
         },
-        startDate: 'Text Date',
+        startDate: '2000-01-01',
       });
     });
-    it('should an object containing an optional route number', () => {
+    it('should return an object containing an optional route number', () => {
       expect(
         provider.formatForExaminerRecords({
           testSummary: { routeNumber: 1 },
           journalData: {
             testSlotAttributes: {
-              start: 'Text Date',
+              start: '2000-01-01',
             } as TestSlotAttributes,
             applicationReference: {
               applicationId: 1,
@@ -163,10 +163,10 @@ describe('ExaminerRecordsProvider', () => {
           costCode: 'EXPLE',
           centreName: 'Example',
         },
-        startDate: 'Text Date',
+        startDate: '2000-01-01',
       });
     });
-    it('should an object containing an optional show me question', () => {
+    it('should return an object containing an optional show me question', () => {
       expect(
         provider.formatForExaminerRecords({
           testData: {
@@ -180,7 +180,7 @@ describe('ExaminerRecordsProvider', () => {
           } as TestData,
           journalData: {
             testSlotAttributes: {
-              start: 'Text Date',
+              start: '2000-01-01',
             } as TestSlotAttributes,
             applicationReference: {
               applicationId: 1,
@@ -204,10 +204,10 @@ describe('ExaminerRecordsProvider', () => {
           costCode: 'EXPLE',
           centreName: 'Example',
         },
-        startDate: 'Text Date',
+        startDate: '2000-01-01',
       });
     });
-    it('should an object containing an optional show me questions array', () => {
+    it('should return an object containing an optional show me questions array', () => {
       expect(
         provider.formatForExaminerRecords({
           testData: {
@@ -223,7 +223,7 @@ describe('ExaminerRecordsProvider', () => {
           } as TestData,
           journalData: {
             testSlotAttributes: {
-              start: 'Text Date',
+              start: '2000-01-01',
             } as TestSlotAttributes,
             applicationReference: {
               applicationId: 1,
@@ -247,10 +247,10 @@ describe('ExaminerRecordsProvider', () => {
           costCode: 'EXPLE',
           centreName: 'Example',
         },
-        startDate: 'Text Date',
+        startDate: '2000-01-01',
       });
     });
-    it('should an object containing an optional tell me question', () => {
+    it('should return an object containing an optional tell me question', () => {
       expect(
         provider.formatForExaminerRecords({
           testData: {
@@ -264,7 +264,7 @@ describe('ExaminerRecordsProvider', () => {
           } as TestData,
           journalData: {
             testSlotAttributes: {
-              start: 'Text Date',
+              start: '2000-01-01',
             } as TestSlotAttributes,
             applicationReference: {
               applicationId: 1,
@@ -288,10 +288,10 @@ describe('ExaminerRecordsProvider', () => {
           costCode: 'EXPLE',
           centreName: 'Example',
         },
-        startDate: 'Text Date',
+        startDate: '2000-01-01',
       });
     });
-    it('should an object containing an optional tell me questions array', () => {
+    it('should return an object containing an optional tell me questions array', () => {
       expect(
         provider.formatForExaminerRecords({
           testData: {
@@ -307,7 +307,7 @@ describe('ExaminerRecordsProvider', () => {
           } as TestData,
           journalData: {
             testSlotAttributes: {
-              start: 'Text Date',
+              start: '2000-01-01',
             } as TestSlotAttributes,
             applicationReference: {
               applicationId: 1,
@@ -331,7 +331,7 @@ describe('ExaminerRecordsProvider', () => {
           costCode: 'EXPLE',
           centreName: 'Example',
         },
-        startDate: 'Text Date',
+        startDate: '2000-01-01',
       });
     });
   });

--- a/src/app/providers/examiner-records/examiner-records.ts
+++ b/src/app/providers/examiner-records/examiner-records.ts
@@ -134,7 +134,7 @@ export class ExaminerRecordsProvider {
       case DateRange.TODAY:
         return moment(new Date());
       case DateRange.WEEK:
-        return moment(new Date()).subtract(5, 'days');
+        return moment(new Date()).subtract(1, 'week');
       case DateRange.FORTNIGHT:
         return moment(new Date()).subtract(2, 'week');
       case DateRange.NINETY_DAYS:

--- a/src/app/providers/examiner-records/examiner-records.ts
+++ b/src/app/providers/examiner-records/examiner-records.ts
@@ -8,7 +8,7 @@ import { Store } from '@ngrx/store';
 import { CompressionProvider } from '@providers/compression/compression';
 import { LoadingProvider } from '@providers/loader/loader';
 import { SearchProvider } from '@providers/search/search';
-import {DateRange, DateTime} from '@shared/helpers/date-time';
+import { DateRange, DateTime } from '@shared/helpers/date-time';
 import { formatApplicationReference } from '@shared/helpers/formatters';
 import { StoreModel } from '@shared/models/store.model';
 import { get } from 'lodash-es';

--- a/src/app/providers/examiner-records/examiner-records.ts
+++ b/src/app/providers/examiner-records/examiner-records.ts
@@ -8,7 +8,7 @@ import { Store } from '@ngrx/store';
 import { CompressionProvider } from '@providers/compression/compression';
 import { LoadingProvider } from '@providers/loader/loader';
 import { SearchProvider } from '@providers/search/search';
-import { DateRange } from '@shared/helpers/date-time';
+import {DateRange, DateTime} from '@shared/helpers/date-time';
 import { formatApplicationReference } from '@shared/helpers/formatters';
 import { StoreModel } from '@shared/models/store.model';
 import { get } from 'lodash-es';
@@ -134,7 +134,7 @@ export class ExaminerRecordsProvider {
       case DateRange.TODAY:
         return moment(new Date());
       case DateRange.WEEK:
-        return moment(new Date()).subtract(1, 'week');
+        return moment(new Date()).subtract(5, 'days');
       case DateRange.FORTNIGHT:
         return moment(new Date()).subtract(2, 'week');
       case DateRange.NINETY_DAYS:
@@ -164,7 +164,7 @@ export class ExaminerRecordsProvider {
       appRef: Number(formatApplicationReference(testResult.journalData.applicationReference)),
       testCategory: testResult.category as TestCategory,
       testCentre: testResult.journalData.testCentre,
-      startDate: testResult.journalData.testSlotAttributes.start,
+      startDate: new DateTime(testResult.journalData.testSlotAttributes.start).format('YYYY-MM-DD'),
     };
 
     [

--- a/src/app/shared/helpers/date-time.ts
+++ b/src/app/shared/helpers/date-time.ts
@@ -88,14 +88,21 @@ export class DateTime {
     return date.moment.diff(this.moment, Duration.SECOND) > 0;
   }
 
-  isDuring(range: DateRange) {
+  isDuring(range: DateRange, setTodayToMidnight = false): boolean {
     const today = new Date();
+
+    if (setTodayToMidnight) {
+      today.setSeconds(0);
+      today.setMinutes(0);
+      today.setHours(0);
+    }
+
     const dateRange = (() => {
       switch (range) {
         case DateRange.TODAY:
           return moment(today).subtract(1, 'day');
         case DateRange.WEEK:
-          return moment(today).subtract(1, 'week');
+          return moment(today).subtract(5, 'days');
         case DateRange.FORTNIGHT:
           return moment(today).subtract(2, 'weeks');
         case DateRange.NINETY_DAYS:

--- a/src/app/shared/helpers/date-time.ts
+++ b/src/app/shared/helpers/date-time.ts
@@ -102,7 +102,7 @@ export class DateTime {
         case DateRange.TODAY:
           return moment(today).subtract(1, 'day');
         case DateRange.WEEK:
-          return moment(today).subtract(5, 'days');
+          return moment(today).subtract(1, 'week');
         case DateRange.FORTNIGHT:
           return moment(today).subtract(2, 'weeks');
         case DateRange.NINETY_DAYS:


### PR DESCRIPTION
## Description
Fixed a bug where tests completed on a previous day would appear in the "today" filter
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
