### PR TITLE
mes-9990-practiceModeModalMOTFix

### DIFF
--- a/src/app/pages/waiting-room-to-car/components/vehicle-registration/vehicle-registration.ts
+++ b/src/app/pages/waiting-room-to-car/components/vehicle-registration/vehicle-registration.ts
@@ -147,8 +147,8 @@ export class VehicleRegistrationComponent implements OnChanges {
           finalize(() => {
             // Stop the search spinner
             this.isSearchingForMOT = false;
-          }
-        ))
+          })
+        )
         .subscribe((val: MotHistoryWithStatus) => {
           // Assign the mock API response to the motData property
           this.motData = val;


### PR DESCRIPTION
## Description
Fixed a bug where practice mode would not cancel the spinner and not allow the user to further use the feature
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
