### PR TITLE
mes-release14-10001-duplicateManoeuvresExaminerRecords

### DIFF
--- a/src/app/pages/examiner-records/__tests__/examiner-records.selector.spec.ts
+++ b/src/app/pages/examiner-records/__tests__/examiner-records.selector.spec.ts
@@ -619,30 +619,45 @@ describe('examiner records selector', () => {
   });
 
   describe('getManoeuvresUsed', () => {
-    it(
-      'should return a list all manoeuvres available for that category and the amount of times they appear, ' +
-        'ordered by index',
-      () => {
-        expect(
-          getManoeuvresUsed(
-            startedTests.filter((value) => value.testCategory == TestCategory.B),
-            TestCategory.B
-          )
-        ).toEqual([
-          { item: 'E1 - Reverse right', count: 0, percentage: '0.0%' },
-          { item: 'E2 - Reverse park (road)', count: 0, percentage: '0.0%' },
-          { item: 'E3 - Reverse park (car park)', count: 0, percentage: '0.0%' },
-          { item: 'E4 - Forward park', count: 1, percentage: '100.0%' },
-        ]);
-      }
-    );
-    it('should return an empty array if passed a category with no manoeuvres', () => {
-      expect(
-        getManoeuvresUsed(
-          startedTests.filter((value) => value.testCategory == TestCategory.ADI3),
-          TestCategory.ADI3
-        )
-      ).toEqual([]);
+    it('returns an empty array if no category is provided', () => {
+      expect(getManoeuvresUsed(startedTests)).toEqual([]);
+    });
+
+    it('returns an empty array if no started tests are provided', () => {
+      expect(getManoeuvresUsed([], TestCategory.B)).toEqual([]);
+    });
+
+    it('returns manoeuvres with their counts and percentages for a given category', () => {
+      const result = getManoeuvresUsed(startedTests, TestCategory.B);
+      expect(result).toEqual([
+        { item: 'E1 - Reverse right', count: 0, percentage: '0.0%' },
+        { item: 'E2 - Reverse park (road)', count: 0, percentage: '0.0%' },
+        { item: 'E3 - Reverse park (car park)', count: 0, percentage: '0.0%' },
+        { item: 'E4 - Forward park', count: 1, percentage: '100.0%' },
+      ]);
+    });
+
+    it('returns an empty array if the category has no manoeuvres', () => {
+      expect(getManoeuvresUsed(startedTests, TestCategory.ADI3)).toEqual([]);
+    });
+
+    it('returns correct counts and percentages when multiple manoeuvres are present', () => {
+      const customTests = [
+        {
+          ...startedTests[2],
+          manoeuvres: [
+            { forwardPark: { selected: true } },
+            { reverseParkRoad: { selected: true, drivingFault: true } },
+          ],
+        },
+      ];
+      const result = getManoeuvresUsed(customTests, TestCategory.B);
+      expect(result).toEqual([
+        { item: 'E1 - Reverse right', count: 0, percentage: '0.0%' },
+        { item: 'E2 - Reverse park (road)', count: 1, percentage: '50.0%' },
+        { item: 'E3 - Reverse park (car park)', count: 0, percentage: '0.0%' },
+        { item: 'E4 - Forward park', count: 1, percentage: '50.0%' },
+      ]);
     });
   });
 });

--- a/src/app/pages/examiner-records/examiner-records.selector.ts
+++ b/src/app/pages/examiner-records/examiner-records.selector.ts
@@ -455,7 +455,7 @@ export const getManoeuvresUsed = (
   startedTests: ExaminerRecordModel[],
   category: TestCategory = null
 ): ExaminerRecordDataWithPercentage<string>[] => {
-  let faultsEncountered: string[] = [];
+  let manoeuvresEncountered: string[] = [];
   let manoeuvreTypeLabels: string[] = [];
   if (category) {
     manoeuvreTypeLabels = Object.values(getManoeuvreTypeLabels(category));
@@ -470,28 +470,24 @@ export const getManoeuvresUsed = (
     const mans = Array.isArray(manoeuvres) ? manoeuvres : [manoeuvres];
     mans.forEach((manoeuvre) => {
       forOwn(manoeuvre, (man: Manoeuvre, type: ManoeuvreTypes) => {
-        const faults = !man.selected
-          ? []
-          : transform(
-              man,
-              (result) => {
-                result.push(getManoeuvreTypeLabels(category, type));
-              },
-              []
-            );
-        faultsEncountered.push(...faults);
+        if (man.selected) {
+          const label = getManoeuvreTypeLabels(category, type);
+          if (label) {
+            manoeuvresEncountered.push(label);
+          }
+        }
       });
     });
-    faultsEncountered = faultsEncountered.filter((fault) => !!fault);
+    manoeuvresEncountered = manoeuvresEncountered.filter((fault) => !!fault);
   });
 
   return manoeuvreTypeLabels
     .map((q, index) => {
-      const count = faultsEncountered.filter((val) => val === q).length;
+      const count = manoeuvresEncountered.filter((val) => val === q).length;
       return {
         item: `E${index + 1} - ${q}`,
         count,
-        percentage: `${((count / faultsEncountered.length) * 100).toFixed(1)}%`,
+        percentage: `${((count / manoeuvresEncountered.length) * 100).toFixed(1)}%`,
       };
     })
     .sort((item1, item2) => getIndex(item1.item as string) - getIndex(item2.item as string));

--- a/src/app/pages/examiner-records/examiner-records.selector.ts
+++ b/src/app/pages/examiner-records/examiner-records.selector.ts
@@ -9,7 +9,7 @@ import { manoeuvreTypeLabels as manoeuvreTypeLabelsCatBE } from '@shared/constan
 import { DateRange, DateTime } from '@shared/helpers/date-time';
 import { isAnyOf } from '@shared/helpers/simplifiers';
 import { ManoeuvreTypes } from '@store/tests/test-data/test-data.constants';
-import { forOwn, get, transform, uniqBy } from 'lodash-es';
+import { forOwn, get, uniqBy } from 'lodash-es';
 
 // Generic `T` is the configurable type of the item
 export interface ExaminerRecordData<T> {
@@ -460,7 +460,7 @@ export const getManoeuvresUsed = (
   if (category) {
     manoeuvreTypeLabels = Object.values(getManoeuvreTypeLabels(category));
   }
-  if (manoeuvreTypeLabels.length == 0 || (!startedTests || startedTests.length == 0)) {
+  if (manoeuvreTypeLabels.length == 0 || !startedTests || startedTests.length == 0) {
     return [];
   }
 

--- a/src/app/pages/examiner-records/examiner-records.selector.ts
+++ b/src/app/pages/examiner-records/examiner-records.selector.ts
@@ -460,7 +460,7 @@ export const getManoeuvresUsed = (
   if (category) {
     manoeuvreTypeLabels = Object.values(getManoeuvreTypeLabels(category));
   }
-  if (manoeuvreTypeLabels.length == 0 || !startedTests) {
+  if (manoeuvreTypeLabels.length == 0 || (!startedTests || startedTests.length == 0)) {
     return [];
   }
 


### PR DESCRIPTION
## Description
Fixed a bug where putting a fault on a manoeuvre will duplicate it in examiner records
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
