### PR TITLE
mes-deletePracticeModeTests

### DIFF
--- a/src/app/pages/dashboard/__tests__/dashboard.page.spec.ts
+++ b/src/app/pages/dashboard/__tests__/dashboard.page.spec.ts
@@ -46,6 +46,7 @@ import {
   selectVersionNumber,
 } from '@store/app-info/app-info.selectors';
 import { LoadJournalSilent } from '@store/journal/journal.actions';
+import { DeletePracticeModeTests } from '@store/tests/tests.actions';
 import { Subscription, of } from 'rxjs';
 import { DashboardComponentsModule } from '../components/dashboard-components.module';
 import { DashboardPageRoutingModule } from '../dashboard-routing.module';
@@ -265,14 +266,15 @@ describe('DashboardPage', () => {
         expect(store$.dispatch).toHaveBeenCalledWith(PracticeTestReportCard());
       });
     });
-    describe('ionViewDidLeave', () => {
+    describe('ionViewWillLeave', () => {
       it('should dispatch a clear action and unsubscribe from page subs', () => {
         component.subscription = new Subscription();
 
         spyOn(component.subscription, 'unsubscribe');
 
-        component.ionViewDidLeave();
+        component.ionViewWillLeave();
         expect(store$.dispatch).toHaveBeenCalledWith(RekeySearchClearState());
+        expect(store$.dispatch).toHaveBeenCalledWith(DeletePracticeModeTests());
         expect(component.subscription.unsubscribe).toHaveBeenCalled();
       });
     });

--- a/src/app/pages/dashboard/dashboard.page.ts
+++ b/src/app/pages/dashboard/dashboard.page.ts
@@ -46,6 +46,7 @@ import * as journalActions from '@store/journal/journal.actions';
 import { JournalRehydrationPage, JournalRehydrationType } from '@store/journal/journal.effects';
 import { getJournalState } from '@store/journal/journal.reducer';
 import { getAllSlots } from '@store/journal/journal.selector';
+import { DeletePracticeModeTests } from '@store/tests/tests.actions';
 import { getTests } from '@store/tests/tests.reducer';
 import { Observable, Subscription, combineLatest, from, merge, takeWhile } from 'rxjs';
 import { filter, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
@@ -167,8 +168,9 @@ export class DashboardPage extends BasePageComponent implements OnInit, ViewDidE
     return true;
   }
 
-  ionViewDidLeave(): void {
+  ionViewWillLeave(): void {
     this.store$.dispatch(RekeySearchClearState());
+    this.store$.dispatch(DeletePracticeModeTests());
 
     if (this.subscription) {
       this.subscription.unsubscribe();

--- a/src/store/tests/tests.actions.ts
+++ b/src/store/tests/tests.actions.ts
@@ -20,6 +20,8 @@ export const LoadRemoteTests = createAction('[Tests] Load remote tests', (tests:
   tests,
 }));
 
+export const DeletePracticeModeTests = createAction('[Tests] Practice Mode tests cleared');
+
 export const TestOutcomeChanged = createAction('[TestReportEffects] Test outcome changed', (outcome: string) => ({
   outcome,
 }));
@@ -108,6 +110,7 @@ const actions = union({
   SendPartialTestSuccess,
   SendPartialTestsFailure,
   SendCompletedNoneSent,
+  DeletePracticeModeTests,
 });
 
 export type TestActionsTypes = typeof actions;

--- a/src/store/tests/tests.reducer.ts
+++ b/src/store/tests/tests.reducer.ts
@@ -3,7 +3,7 @@ import { get } from 'lodash-es';
 
 import { Action, createFeatureSelector } from '@ngrx/store';
 import * as fakeJournalActions from '@pages/fake-journal/fake-journal.actions';
-import { testReportPracticeSlotId } from '@shared/mocks/test-slot-ids.mock';
+import { end2endPracticeSlotId, testReportPracticeSlotId } from '@shared/mocks/test-slot-ids.mock';
 import * as testsActions from './tests.actions';
 import { LoadPersistedTestsSuccess, LoadRemoteTests } from './tests.actions';
 import { TestsModel } from './tests.model';
@@ -132,6 +132,16 @@ export function testsReducer(
   switch (action.type) {
     case testsActions.UnloadTests.type:
       return initialState;
+    case testsActions.DeletePracticeModeTests.type:
+      let newState: TestsModel = state;
+      // Get every practice mode slot and delete it
+      const practiceSlots: string[] = Object.keys(state.startedTests).filter(
+        (key) => key.startsWith(end2endPracticeSlotId) || key.startsWith(testReportPracticeSlotId)
+      );
+      practiceSlots.forEach((slot: string) => {
+        newState = removeTest(newState, slot);
+      });
+      return newState;
     case testsActions.LoadRemoteTests.type:
       return hydrateRemoteTests(state, (<ReturnType<typeof LoadRemoteTests>>action).tests);
     case testsActions.LoadPersistedTestsSuccess.type:


### PR DESCRIPTION
## Description
Added functionality to remove practice mode tests from the store when you leave the dashboard

## Checklist

- [ ] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
