### PR TITLE
MES-10152: remove ability to run fastlane through different versions of Xcode

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -2,7 +2,7 @@ default_platform(:ios)
 
 before_all do
   clean(dirs: './builds ./simulator ./certs ./codes')
-  xcode_select("/Applications/Xcode-#{ENV["XCODE_VERSION"]}.app")
+  xcode_select("/Applications/Xcode.app")
 end
 
 desc "Build the Simulator File for the Automation Suite"


### PR DESCRIPTION
## Description
remove ability to run fastlane through different versions of Xcode

Related issue: [MES-10152](https://dvsa.atlassian.net/browse/MES-10152)

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
