### PR TITLE
mes-10212-newModalSizingCandidateDetailsFix

### DIFF
--- a/src/components/test-slot/test-outcome/test-outcome.ts
+++ b/src/components/test-slot/test-outcome/test-outcome.ts
@@ -295,7 +295,7 @@ export class TestOutcomeComponent implements OnInit {
         slot: this.slot,
         slotChanged: this.slotChanged,
         isTeamJournal: !this.showTestActionButton,
-        textZoomClass: `mes-modal-alert ${this.accessibilityService.getTextZoomClass()}`,
+        textZoomClass: `${this.accessibilityService.getTextZoomClass()}`,
       },
       cssClass: 'mes-modal-alert text-zoom-regular',
     });


### PR DESCRIPTION
## Description
removed redundant CSS which caused the candidate details modal to appear as the wrong size
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
