### PR TITLE
mes-10257-altEvidenceNotSaving

### DIFF
--- a/src/app/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
+++ b/src/app/pages/office/cat-a-mod1/office.cat-a-mod1.page.html
@@ -110,14 +110,15 @@
             </vehicle-details-card>
 
             <alternate-mot-evidence-provided
-              *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+              *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
             ></alternate-mot-evidence-provided>
 
             <alternate-mot-evidence-description
               [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-              *ngIf="pageState.motAlternativeEvidenceProvided | async"
+              *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
+              [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
               (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
               [formGroup]="form"
             >

--- a/src/app/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
+++ b/src/app/pages/office/cat-a-mod2/office.cat-a-mod2.page.html
@@ -135,14 +135,15 @@
             </vehicle-details-card>
 
             <alternate-mot-evidence-provided
-              *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+              *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
             ></alternate-mot-evidence-provided>
 
             <alternate-mot-evidence-description
               [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-              *ngIf="pageState.motAlternativeEvidenceProvided | async"
+              *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
+              [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
               (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
               [formGroup]="form"
             >

--- a/src/app/pages/office/cat-adi-part2/office.cat-adi-part2.page.html
+++ b/src/app/pages/office/cat-adi-part2/office.cat-adi-part2.page.html
@@ -148,14 +148,15 @@
             </accompaniment-card>
 
             <alternate-mot-evidence-provided
-              *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+              *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
             ></alternate-mot-evidence-provided>
 
             <alternate-mot-evidence-description
               [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-              *ngIf="pageState.motAlternativeEvidenceProvided | async"
+              *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
+              [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
               (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
               [formGroup]="form"
             >

--- a/src/app/pages/office/cat-adi-part3/office.cat-adi-part3.page.html
+++ b/src/app/pages/office/cat-adi-part3/office.cat-adi-part3.page.html
@@ -37,15 +37,16 @@
           </activity-code>
 
           <alternate-mot-evidence-provided
-            *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-            [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-            [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+            *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+            [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+            [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
           ></alternate-mot-evidence-provided>
 
           <alternate-mot-evidence-description
             [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-            *ngIf="pageState.motAlternativeEvidenceProvided | async"
+            *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
             (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
+            [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
             [formGroup]="form"
           >
           </alternate-mot-evidence-description>

--- a/src/app/pages/office/cat-b/office.cat-b.page.html
+++ b/src/app/pages/office/cat-b/office.cat-b.page.html
@@ -154,16 +154,17 @@
             </vehicle-details-card>
 
             <alternate-mot-evidence-provided
-              *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+              *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
             ></alternate-mot-evidence-provided>
 
             <alternate-mot-evidence-description
               [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-              *ngIf="pageState.motAlternativeEvidenceProvided | async"
+              *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
               (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
               [formGroup]="form"
+              [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
             >
             </alternate-mot-evidence-description>
 

--- a/src/app/pages/office/cat-c/office.cat-c.page.html
+++ b/src/app/pages/office/cat-c/office.cat-c.page.html
@@ -205,14 +205,15 @@
             </accompaniment-card>
 
             <alternate-mot-evidence-provided
-              *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+              *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
             ></alternate-mot-evidence-provided>
 
             <alternate-mot-evidence-description
               [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-              *ngIf="pageState.motAlternativeEvidenceProvided | async"
+              *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
+              [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
               (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
               [formGroup]="form"
             >

--- a/src/app/pages/office/cat-cpc/office.cat-cpc.page.html
+++ b/src/app/pages/office/cat-cpc/office.cat-cpc.page.html
@@ -123,14 +123,15 @@
             </identification>
 
             <alternate-mot-evidence-provided
-              *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+              *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
             ></alternate-mot-evidence-provided>
 
             <alternate-mot-evidence-description
               [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-              *ngIf="pageState.motAlternativeEvidenceProvided | async"
+              *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
+              [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
               (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
               [formGroup]="form"
             >

--- a/src/app/pages/office/cat-d/office.cat-d.page.html
+++ b/src/app/pages/office/cat-d/office.cat-d.page.html
@@ -209,14 +209,15 @@
             ></reason-for-entering-teams>
 
             <alternate-mot-evidence-provided
-              *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+              *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
             ></alternate-mot-evidence-provided>
 
             <alternate-mot-evidence-description
               [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-              *ngIf="pageState.motAlternativeEvidenceProvided | async"
+              *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
+              [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
               (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
               [formGroup]="form"
             >

--- a/src/app/pages/office/cat-home-test/office.cat-home-test.page.html
+++ b/src/app/pages/office/cat-home-test/office.cat-home-test.page.html
@@ -95,14 +95,15 @@
             </accompaniment-card>
 
             <alternate-mot-evidence-provided
-              *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+              *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
             ></alternate-mot-evidence-provided>
 
             <alternate-mot-evidence-description
               [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-              *ngIf="pageState.motAlternativeEvidenceProvided | async"
+              *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
+              [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
               (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
               [formGroup]="form"
             >

--- a/src/app/pages/office/cat-manoeuvre/office.cat-manoeuvre.page.html
+++ b/src/app/pages/office/cat-manoeuvre/office.cat-manoeuvre.page.html
@@ -154,14 +154,15 @@
             </accompaniment-card>
 
             <alternate-mot-evidence-provided
-              *ngIf="(pageState.motAlternativeEvidenceProvided | async) != null"
-              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided | async"
-              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided | async) || (pageState.displayAdditionalInformation$ | async)"
+              *ngIf="(pageState.motAlternativeEvidenceProvided$ | async) != null"
+              [alternativeEvidenceProvided]="pageState.motAlternativeEvidenceProvided$ | async"
+              [shouldHaveSeparator]="(pageState.motAlternativeEvidenceProvided$ | async) || (pageState.displayAdditionalInformation$ | async)"
             ></alternate-mot-evidence-provided>
 
             <alternate-mot-evidence-description
               [shouldHaveSeparator]="pageState.displayAdditionalInformation$ | async"
-              *ngIf="pageState.motAlternativeEvidenceProvided | async"
+              *ngIf="pageState.motAlternativeEvidenceProvided$ | async"
+              [alternateEvidenceDescription]="pageState.motAlternativeEvidenceDescription$ | async"
               (evidenceDescriptionTestResultChange)="alternativeMOTEvidenceDescriptionUpdated($event)"
               [formGroup]="form"
             >

--- a/src/app/pages/office/components/alternate-mot-evidence-description/__tests__/alternate-evidence-description.component.spec.ts
+++ b/src/app/pages/office/components/alternate-mot-evidence-description/__tests__/alternate-evidence-description.component.spec.ts
@@ -24,37 +24,33 @@ describe('AlternateEvidenceDescriptionComponent', () => {
   }));
 
   describe('ngOnChanges', () => {
-    it('should create and set up the form control when it does not exist', () => {
+    it('should create formControl if it does not exist', () => {
       component.formControl = null;
       component.ngOnChanges();
-
       expect(component.formControl).toBeDefined();
       expect(component.formControl instanceof UntypedFormControl).toBe(true);
-
-      // Check if the validator function is defined
-      expect(component.formControl.validator).toBeDefined();
     });
-    it('should add the form control to the form group when it does not exist', () => {
-      spyOn(component.formGroup, 'contains').and.returnValue(false);
+
+    it('should patch formControl value with alternateEvidenceDescription', () => {
       component.formControl = null;
-
+      component.alternateEvidenceDescription = 'Test Description';
       component.ngOnChanges();
-
-      expect(component.formControl).toBeDefined();
-      expect(component.formControl instanceof UntypedFormControl).toBe(true);
-      expect(component.formGroup.controls.altEvidenceDetailsCtrl).toBe(component.formControl);
+      expect(component.formControl.value).toBe('Test Description');
     });
-    it('should patch altEvidenceDetailsCtrl into the formControl when it does exist', () => {
+
+    it('should add formControl to formGroup if altEvidenceDetailsCtrl does not exist', () => {
+      component.formControl = null;
+      component.formGroup = new UntypedFormGroup({});
+      component.ngOnChanges();
+      console.log(component.formGroup.contains('altEvidenceDetailsCtrl'));
+      expect(component.formGroup.contains('altEvidenceDetailsCtrl')).toBeTrue();
+    });
+
+    it('should set formControl in formGroup if altEvidenceDetailsCtrl exists', () => {
+      component.formControl = null;
       spyOn(component.formGroup, 'contains').and.returnValue(true);
-      component.formControl = null;
-      component.formGroup.addControl('altEvidenceDetailsCtrl', new UntypedFormControl('string'));
-
       component.ngOnChanges();
-
-      expect(component.formControl).toBeDefined();
-      expect(component.formControl instanceof UntypedFormControl).toBe(true);
       expect(component.formGroup.controls.altEvidenceDetailsCtrl).toBe(component.formControl);
-      expect(component.formControl.value).toEqual('string');
     });
   });
 

--- a/src/app/pages/office/components/alternate-mot-evidence-description/alternate-evidence-description.component.ts
+++ b/src/app/pages/office/components/alternate-mot-evidence-description/alternate-evidence-description.component.ts
@@ -15,18 +15,20 @@ export class AlternateEvidenceDescriptionComponent {
   @Input()
   formGroup: UntypedFormGroup;
 
+  @Input()
+  alternateEvidenceDescription: string;
+
   @Output()
   evidenceDescriptionTestResultChange = new EventEmitter<string>();
-
-  evidenceDescription: string;
 
   ngOnChanges(): void {
     if (!this.formControl) {
       this.formControl = new UntypedFormControl('', [Validators.required]);
+      this.formControl.patchValue(this.alternateEvidenceDescription);
       if (this.formGroup.contains('altEvidenceDetailsCtrl')) {
-        this.formControl.patchValue(this.formGroup.controls.altEvidenceDetailsCtrl.value);
         this.formGroup.setControl('altEvidenceDetailsCtrl', this.formControl);
       } else {
+        console.log('Adding altEvidenceDetailsCtrl to formGroup', this.formControl);
         this.formGroup.addControl('altEvidenceDetailsCtrl', this.formControl);
       }
     }

--- a/src/app/pages/office/components/alternate-mot-evidence-description/alternate-mot-evidence-description.component.html
+++ b/src/app/pages/office/components/alternate-mot-evidence-description/alternate-mot-evidence-description.component.html
@@ -15,7 +15,7 @@
           pasteSanitiser
           [maxlength]="1000"
           [class.ng-invalid]="invalid"
-          [value]="evidenceDescription"
+          [value]="alternateEvidenceDescription"
           (change)="evidenceDescriptionTestResultChanged($event.target.value)"
         >
         </textarea>

--- a/src/app/shared/classes/test-flow-base-pages/office/office-base-page.ts
+++ b/src/app/shared/classes/test-flow-base-pages/office/office-base-page.ts
@@ -138,7 +138,10 @@ import {
   SchoolBikeToggled,
   SchoolCarToggled,
 } from '@store/tests/vehicle-details/vehicle-details.actions';
-import { getMotEvidenceProvided } from '@store/tests/vehicle-details/vehicle-details.selector';
+import {
+  getMotEvidenceDescription,
+  getMotEvidenceProvided,
+} from '@store/tests/vehicle-details/vehicle-details.selector';
 import { map, withLatestFrom } from 'rxjs/operators';
 
 export interface CommonOfficePageState {
@@ -189,9 +192,10 @@ export interface CommonOfficePageState {
   supervisorAccompaniment$: Observable<boolean>;
   otherAccompaniment$: Observable<boolean>;
   interpreterAccompaniment$: Observable<boolean>;
-  motAlternativeEvidenceProvided: Observable<boolean>;
+  motAlternativeEvidenceProvided$: Observable<boolean>;
   hasEnteredTeamsOnThisTest$: Observable<boolean>;
   reasonForEnteringTeams$: Observable<string>;
+  motAlternativeEvidenceDescription$: Observable<string>;
 }
 
 export abstract class OfficeBasePageComponent extends PracticeableBasePageComponent {
@@ -236,6 +240,11 @@ export abstract class OfficeBasePageComponent extends PracticeableBasePageCompon
     const category$ = currentTest$.pipe(select(getTestCategory));
 
     this.commonPageState = {
+      motAlternativeEvidenceProvided$: currentTest$.pipe(select(getVehicleDetails), select(getMotEvidenceProvided)),
+      motAlternativeEvidenceDescription$: currentTest$.pipe(
+        select(getVehicleDetails),
+        select(getMotEvidenceDescription)
+      ),
       hasEnteredTeamsOnThisTest$: currentTest$.pipe(select(getUserExitedApp), select(getUserHasExitedApp)),
       reasonForEnteringTeams$: currentTest$.pipe(select(getUserExitedApp), select(getReasonForExitingApp)),
       activityCode$: currentTest$.pipe(select(getActivityCode)),
@@ -403,7 +412,6 @@ export abstract class OfficeBasePageComponent extends PracticeableBasePageCompon
       supervisorAccompaniment$: currentTest$.pipe(select(getAccompaniment), select(getSupervisorAccompaniment)),
       otherAccompaniment$: currentTest$.pipe(select(getAccompaniment), select(getOtherAccompaniment)),
       interpreterAccompaniment$: currentTest$.pipe(select(getAccompaniment), select(getInterpreterAccompaniment)),
-      motAlternativeEvidenceProvided: currentTest$.pipe(select(getVehicleDetails), select(getMotEvidenceProvided)),
     };
   }
 

--- a/src/store/tests/vehicle-details/vehicle-details.selector.ts
+++ b/src/store/tests/vehicle-details/vehicle-details.selector.ts
@@ -6,6 +6,7 @@ export const getRegistrationNumber = (vehicleDetails: VehicleDetails) => vehicle
 export const getGearboxCategory = (vehicleDetails: VehicleDetails) => vehicleDetails.gearboxCategory;
 export const getMotStatus = (vehicleDetails: VehicleDetails) => vehicleDetails.motStatus;
 export const getMotEvidenceProvided = (vehicleDetails: VehicleDetails) => vehicleDetails.motEvidenceProvided;
+export const getMotEvidenceDescription = (vehicleDetails: VehicleDetails) => vehicleDetails.motEvidence;
 export const getVehicleMake = (vehicleDetails: VehicleDetails) => vehicleDetails.make;
 export const getVehicleModel = (vehicleDetails: VehicleDetails) => vehicleDetails.model;
 export const getTestExpiryDate = (vehicleDetails: VehicleDetails) => vehicleDetails.testExpiryDate;


### PR DESCRIPTION
## Description
Added ability to correctly save and display alternate MOT evidence
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
