### PR TITLE
mes-10059-escapeFromSAMBugFix

### DIFF
--- a/src/components/common/test-flow-header/_tests_/test-flow-header.component.spec.ts
+++ b/src/components/common/test-flow-header/_tests_/test-flow-header.component.spec.ts
@@ -280,11 +280,9 @@ describe('TestFlowHeaderComponent', () => {
       expect(component.handleTeamsOpenFailure).toHaveBeenCalledWith({ completed: false });
     });
 
-    it('should setup subscription if Microsoft Teams opens successfully', async () => {
+    it('should setup subscription if single app mode is disabled', async () => {
       component.isPracticeMode = false;
       spyOn(deviceProvider, 'disableSingleAppMode').and.resolveTo(true);
-      spyOn(AppLauncher, 'canOpenUrl').and.resolveTo({ value: true });
-      spyOn(AppLauncher, 'openUrl').and.resolveTo({ completed: true });
       spyOn(component, 'setupResumeSubscription');
 
       await component.disableSAMAndExit(ExitSAMMethodUsed.BANNER);

--- a/src/components/common/test-flow-header/test-flow-header.component.ts
+++ b/src/components/common/test-flow-header/test-flow-header.component.ts
@@ -236,6 +236,9 @@ export class TestFlowHeaderComponent {
         return;
       }
 
+      // If disabling single app mode was successful, set up the resume subscription
+      this.setupResumeSubscription();
+
       // Define the Microsoft Teams URL
       const teamsURL = 'msteams://teams.microsoft.com';
       // Check if the URL can be opened
@@ -250,12 +253,10 @@ export class TestFlowHeaderComponent {
       // Attempt to open the URL
       const openURLResult = await AppLauncher.openUrl({ url: teamsURL });
 
-      // If the URL was opened successfully, set up the subscription
-      if (openURLResult.completed) {
-        this.setupResumeSubscription();
-      } else {
+      if (!openURLResult.completed) {
         // If opening the URL failed, handle the failure
         await this.handleTeamsOpenFailure(openURLResult);
+        return;
       }
     } catch (e) {
       // Handle any errors that occurred during the process


### PR DESCRIPTION
Fixed a bug where SAM would not lock the user back in if teams was not available

## Description

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
