### PR TITLE
mes-10335-passCertificateManoeuvreNull

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,16 +6,16 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: Missing Release of Resource after Effective Lifetime - Remediation not yet available
-        expires: 2025-04-01T09:00:00.119Z
+        expires: 2025-05-01T09:00:00.119Z
         created: 2023-12-04T09:00:00.122Z
   SNYK-JS-ELLIPTIC-8187303:
     - '*':
         reason: Improper Verification of Cryptographic Signature - No upgrade or patch available
-        expires: 2025-04-01T09:00:00.119Z
+        expires: 2025-05-01T09:00:00.119Z
         created: 2025-02-07T09:00:00.122Z
   SNYK-JS-BABELHELPERS-9397697:
       - '*':
           reason: Regular Expression Denial of Service (ReDoS) - No direct upgrade or patch available
-          expires: 2025-04-01T09:00:00.119Z
+          expires: 2025-05-01T09:00:00.119Z
           created: 2023-12-04T09:00:00.122Z
 patch: {}

--- a/src/app/pages/waiting-room/__tests__/waiting-room.page.spec.ts
+++ b/src/app/pages/waiting-room/__tests__/waiting-room.page.spec.ts
@@ -244,6 +244,11 @@ describe('WaitingRoomPage', () => {
         component.manoeuvresPassCertNumberChanged('123');
         expect(store$.dispatch).toHaveBeenCalledWith(preTestDeclarationsActions.ManoeuvresPassCertNumberChanged('123'));
       });
+
+      it('should dispatch ManoeuvresPassCertNumberChanged with null if no certificate number is provided', () => {
+        component.manoeuvresPassCertNumberChanged('');
+        expect(store$.dispatch).toHaveBeenCalledWith(preTestDeclarationsActions.ManoeuvresPassCertNumberChanged(null));
+      });
     });
 
     describe('dispatchCandidateChoseToProceedInWelsh', () => {

--- a/src/app/pages/waiting-room/components/manoeuvres-pass-cert/__tests__/manoeuvres-pass-cert.spec.ts
+++ b/src/app/pages/waiting-room/components/manoeuvres-pass-cert/__tests__/manoeuvres-pass-cert.spec.ts
@@ -38,6 +38,33 @@ describe('ManoeuvresPassCertificateComponent', () => {
       });
     });
 
+    describe('manoeuvresPassCertificateNumberChanged', () => {
+      it('should emit manoeuvre pass certificate number in uppercase if valid', () => {
+        spyOn(component.manoeuvresPassCertificateNumberChange, 'emit');
+        const passCertificateNumber = 'c267548e';
+        component.manoeuvresPassCertificateNumberChanged(passCertificateNumber);
+        expect(component.manoeuvresPassCertificateNumberChange.emit).toHaveBeenCalledWith('C267548E');
+      });
+
+      it('should emit undefined if pass certificate number is null', () => {
+        spyOn(component.manoeuvresPassCertificateNumberChange, 'emit');
+        component.manoeuvresPassCertificateNumberChanged(null);
+        expect(component.manoeuvresPassCertificateNumberChange.emit).toHaveBeenCalledWith(undefined);
+      });
+
+      it('should emit undefined if pass certificate number is undefined', () => {
+        spyOn(component.manoeuvresPassCertificateNumberChange, 'emit');
+        component.manoeuvresPassCertificateNumberChanged(undefined);
+        expect(component.manoeuvresPassCertificateNumberChange.emit).toHaveBeenCalledWith(undefined);
+      });
+
+      it('should emit empty string if pass certificate number is empty', () => {
+        spyOn(component.manoeuvresPassCertificateNumberChange, 'emit');
+        component.manoeuvresPassCertificateNumberChanged('');
+        expect(component.manoeuvresPassCertificateNumberChange.emit).toHaveBeenCalledWith('');
+      });
+    });
+
     describe('get invalid', () => {
       it('should return false when the field is valid and not dirty', () => {
         // SETUP

--- a/src/app/pages/waiting-room/waiting-room.page.ts
+++ b/src/app/pages/waiting-room/waiting-room.page.ts
@@ -238,7 +238,10 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
   };
 
   manoeuvresPassCertNumberChanged(manoeuvresPassCert: string): void {
-    this.store$.dispatch(preTestDeclarationsActions.ManoeuvresPassCertNumberChanged(manoeuvresPassCert));
+    console.log(manoeuvresPassCert, manoeuvresPassCert ? manoeuvresPassCert : null);
+    this.store$.dispatch(
+      preTestDeclarationsActions.ManoeuvresPassCertNumberChanged(manoeuvresPassCert ? manoeuvresPassCert : null)
+    );
   }
 
   signatureChanged(signature: string): void {

--- a/src/directives/__tests__/emoji-block.directive.spec.ts
+++ b/src/directives/__tests__/emoji-block.directive.spec.ts
@@ -17,9 +17,27 @@ describe('EmojiBlockDirective', () => {
     directive = new EmojiBlockDirective(elementRefMock as ElementRef);
   });
 
-  it('should sanitize emojis from input data', () => {
+  it('should not modify value if inputField is null', () => {
+    elementRefMock.nativeElement = null;
     directive.onInput();
+    expect(elementRefMock.nativeElement).toBeNull();
+  });
 
+  it('should not modify value if inputField value is empty', () => {
+    elementRefMock.nativeElement.value = '';
+    directive.onInput();
+    expect(elementRefMock.nativeElement.value).toBe('');
+  });
+
+  it('should remove emojis from inputField value', () => {
+    elementRefMock.nativeElement.value = 'Hello😀 World🌎';
+    directive.onInput();
+    expect(elementRefMock.nativeElement.value).toBe('Hello World');
+  });
+
+  it('should not modify value if there are no emojis', () => {
+    elementRefMock.nativeElement.value = 'Hello World';
+    directive.onInput();
     expect(elementRefMock.nativeElement.value).toBe('Hello World');
   });
 });

--- a/src/directives/emoji-block.directive.ts
+++ b/src/directives/emoji-block.directive.ts
@@ -13,7 +13,9 @@ export class EmojiBlockDirective {
   onInput(): void {
     // Grab element
     const inputField = this.el.nativeElement;
-    if (!inputField) return;
+
+    // Check if inputField is null or empty
+    if (!inputField || !inputField?.value) return;
 
     // Strip emojis out
     inputField.value = inputField.value.replace(this.emojiPattern, '');


### PR DESCRIPTION
## Description
Changed logic to emit a null value if the string is empty to avoid database errors

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
