### PR TITLE
mes-10474-ShowIndependantTargetForCatBAndAdi2Only

### DIFF
--- a/src/app/pages/examiner-records/examiner-records.page.html
+++ b/src/app/pages/examiner-records/examiner-records.page.html
@@ -255,6 +255,7 @@
             >
             </data-row>
             <data-row
+              *ngIf="shouldDisplayIndependentDrivingTarget()"
               class="additional-data-row target-padding"
               [customLabelWidth]="50"
               [rowStyling]="{'padding': '0', 'font-style': 'italic'}"

--- a/src/app/pages/examiner-records/examiner-records.page.ts
+++ b/src/app/pages/examiner-records/examiner-records.page.ts
@@ -853,6 +853,12 @@ export class ExaminerRecordsPage implements OnInit {
     ]);
 
   /**
+   * Returns whether the independent driving target should be displayed.
+   */
+  public shouldDisplayIndependentDrivingTarget = (): boolean =>
+    isAnyOf(this.currentCategory, [TestCategory.B, TestCategory.ADI2]);
+
+  /**
    * Get the total number of individual instances of data.
    *
    * This method takes an array of `ExaminerRecordData` objects and calculates the total count


### PR DESCRIPTION
Added Independent Driving recommended filter so that it only displays on cat b and adi2

## Description

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
