### PR TITLE
mes-release-10474-ShowIndependantTargetForCatBAndAdi2Only

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -6,6 +6,11 @@ ignore:
   SNYK-JS-INFLIGHT-6095116:
     - '*':
         reason: Missing Release of Resource after Effective Lifetime - Remediation not yet available
-        expires: 2025-07-01T09:00:00.119Z
+        expires: 2025-08-01T09:00:00.119Z
         created: 2023-12-04T09:00:00.122Z
+  SNYK-JS-BRACEEXPANSION-9789073:
+    - '*':
+        reason: Missing Release of Resource after Effective Lifetime - Remediation not yet available
+        expires: 2025-08-01T09:00:00.119Z
+        created: 2023-7-12T09:00:00.122Z
 patch: {}

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="uk.gov.dvsa.drivingexaminerservices" version="4.20.1.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="uk.gov.dvsa.drivingexaminerservices" version="4.20.1.2" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>DES</name>
     <description>An application for DVSA driving examiners to conduct driving tests digitally</description>
     <content src="index.html" />

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.20.1.1</string>
+	<string>4.20.1.2</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -41,7 +41,7 @@
         <string>msteams</string>
     </array>
 	<key>CFBundleVersion</key>
-	<string>4.20.1.1</string>
+	<string>4.20.1.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSCameraUsageDescription</key>

--- a/src/app/pages/examiner-records/examiner-records.page.html
+++ b/src/app/pages/examiner-records/examiner-records.page.html
@@ -253,6 +253,7 @@
             >
             </data-row>
             <data-row
+              *ngIf="shouldDisplayIndependentDrivingTarget()"
               class="additional-data-row target-padding"
               [customLabelWidth]="50"
               [rowStyling]="{'padding': '0', 'font-style': 'italic'}"

--- a/src/app/pages/examiner-records/examiner-records.page.ts
+++ b/src/app/pages/examiner-records/examiner-records.page.ts
@@ -853,6 +853,12 @@ export class ExaminerRecordsPage implements OnInit {
     ]);
 
   /**
+   * Returns whether the independent driving target should be displayed.
+   */
+  public shouldDisplayIndependentDrivingTarget = (): boolean =>
+    isAnyOf(this.currentCategory, [TestCategory.B, TestCategory.ADI2]);
+
+  /**
    * Get the total number of individual instances of data.
    *
    * This method takes an array of `ExaminerRecordData` objects and calculates the total count


### PR DESCRIPTION
## Description
Added Independent Driving recommended filter so that it only displays on cat b and adi2

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
