### PR TITLE
feat: (mes-10659) Search for completed tests - Normal Stop

### DIFF
--- a/src/app/pages/view-test-result/components/debrief-card/debrief-card.ts
+++ b/src/app/pages/view-test-result/components/debrief-card/debrief-card.ts
@@ -238,14 +238,10 @@ export class DebriefCardComponent implements OnInit {
     ]);
 
   public getTestRequirementsCatADI2 = (): DataRowListItem[] => {
-    return [
+    const requirements: DataRowListItem[] = [
       {
         label: TestRequirementsLabels.normalStop1,
         checked: get(this.data, 'testRequirements.normalStart1', false),
-      },
-      {
-        label: TestRequirementsLabels.normalStop2,
-        checked: get(this.data, 'testRequirements.normalStart2', false),
       },
       {
         label: TestRequirementsLabels.angledStart,
@@ -260,17 +256,23 @@ export class DebriefCardComponent implements OnInit {
         checked: get(this.data, 'testRequirements.downhillStart', false),
       },
     ];
+
+    // Only add normalStop2 if it exists in the data
+    if (get(this.data, 'testRequirements.normalStart2') !== undefined) {
+      requirements.splice(1, 0, {
+        label: TestRequirementsLabels.normalStop2,
+        checked: get(this.data, 'testRequirements.normalStart2', false),
+      });
+    }
+
+    return requirements;
   };
 
   public getTestRequirementsCatB = (): DataRowListItem[] => {
-    return [
+    const requirements: DataRowListItem[] = [
       {
         label: TestRequirementsLabels.normalStop1,
         checked: get(this.data, 'testRequirements.normalStart1', false),
-      },
-      {
-        label: TestRequirementsLabels.normalStop2,
-        checked: get(this.data, 'testRequirements.normalStart2', false),
       },
       {
         label: TestRequirementsLabels.angledStart,
@@ -281,6 +283,16 @@ export class DebriefCardComponent implements OnInit {
         checked: get(this.data, 'testRequirements.hillStart', false),
       },
     ];
+
+    // Only add normalStop2 if it exists in the data
+    if (get(this.data, 'testRequirements.normalStart2') !== undefined) {
+      requirements.splice(1, 0, {
+        label: TestRequirementsLabels.normalStop2,
+        checked: get(this.data, 'testRequirements.normalStart2', false),
+      });
+    }
+
+    return requirements;
   };
 
   public getTestRequirementsCatC = (): DataRowListItem[] => {

--- a/src/app/pages/view-test-result/components/debrief-card/debrief-card.ts
+++ b/src/app/pages/view-test-result/components/debrief-card/debrief-card.ts
@@ -238,10 +238,14 @@ export class DebriefCardComponent implements OnInit {
     ]);
 
   public getTestRequirementsCatADI2 = (): DataRowListItem[] => {
-    const requirements: DataRowListItem[] = [
+    return [
       {
         label: TestRequirementsLabels.normalStop1,
         checked: get(this.data, 'testRequirements.normalStart1', false),
+      },
+      {
+        label: TestRequirementsLabels.normalStop2,
+        checked: get(this.data, 'testRequirements.normalStart2', false),
       },
       {
         label: TestRequirementsLabels.angledStart,
@@ -256,16 +260,6 @@ export class DebriefCardComponent implements OnInit {
         checked: get(this.data, 'testRequirements.downhillStart', false),
       },
     ];
-
-    // Only add normalStop2 if it exists in the data
-    if (get(this.data, 'testRequirements.normalStart2') !== undefined) {
-      requirements.splice(1, 0, {
-        label: TestRequirementsLabels.normalStop2,
-        checked: get(this.data, 'testRequirements.normalStart2', false),
-      });
-    }
-
-    return requirements;
   };
 
   public getTestRequirementsCatB = (): DataRowListItem[] => {

--- a/src/app/pages/view-test-result/components/test-summary-card/__tests__/test-summary-card.spec.ts
+++ b/src/app/pages/view-test-result/components/test-summary-card/__tests__/test-summary-card.spec.ts
@@ -3,6 +3,7 @@ import { DataRowCustomComponent } from '@components/common/data-row-custom/data-
 import { DataRowComponent } from '@components/common/data-row/data-row';
 import { ModeOfTransport } from '@dvsa/mes-test-schema/categories/AM2';
 import { IndependentDriving, WeatherConditions } from '@dvsa/mes-test-schema/categories/common';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { IonicModule } from '@ionic/angular';
 import { MockComponent } from 'ng-mocks';
 import { TestSummaryCardComponent } from '../test-summary-card';
@@ -155,6 +156,20 @@ describe('TestSummaryCardComponent', () => {
       });
 
       it('should return None if the testSummary is missing', () => {
+        expect(component.independentDriving).toEqual('None');
+      });
+
+      it('should return false if isCatB is true and independentDriving is missing', () => {
+        component.category = TestCategory.B;
+        component.testSummary = {};
+        fixture.detectChanges();
+        expect(component.independentDriving).toEqual(false);
+      });
+
+      it('should return none if isCatB is false and independentDriving is missing', () => {
+        component.category = TestCategory.C;
+        component.testSummary = {};
+        fixture.detectChanges();
         expect(component.independentDriving).toEqual('None');
       });
     });

--- a/src/app/pages/view-test-result/components/test-summary-card/test-summary-card.html
+++ b/src/app/pages/view-test-result/components/test-summary-card/test-summary-card.html
@@ -31,7 +31,9 @@
       }
 
       @if (!isADI3() && !isSC()) {
-        <data-row [label]="'Independent driving'" [value]="independentDriving"></data-row>
+        @if (!isCatB() || independentDriving !== false) {
+          <data-row [label]="'Independent driving'" [value]="independentDriving"></data-row>
+        }
         <data-row
           [label]="'Candidate appearance true likeness to photo'"
           [value]="trueLikenessToPhoto ? 'Yes' : 'No'"

--- a/src/app/pages/view-test-result/components/test-summary-card/test-summary-card.ts
+++ b/src/app/pages/view-test-result/components/test-summary-card/test-summary-card.ts
@@ -81,7 +81,13 @@ export class TestSummaryCardComponent {
     return get(this.testSummary, 'routeNumber', 'None');
   }
 
-  public get independentDriving(): string {
+  /**
+   * For Cat B, if independentDriving is not set, return false
+   */
+  public get independentDriving(): string | boolean {
+    if (this.isCatB() && !('independentDriving' in this.testSummary)) {
+      return false;
+    }
     return get(this.testSummary, 'independentDriving', 'None');
   }
 
@@ -140,5 +146,9 @@ export class TestSummaryCardComponent {
 
   isSC() {
     return this.category === TestCategory.SC;
+  }
+
+  isCatB() {
+    return this.category === TestCategory.B;
   }
 }


### PR DESCRIPTION
## Description

Dynamically display normal stops on CATB and ADI2 on the test requirements card if ns2 is present


## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

Old tests still display:

<img width="573" height="225" alt="image" src="https://github.com/user-attachments/assets/877fa805-d170-4965-bbf4-fb315510bfe9" />

<img width="587" height="212" alt="image" src="https://github.com/user-attachments/assets/478d0515-073a-472b-9526-da542150c57b" />

new tests from mes-10643

<img width="575" height="195" alt="image" src="https://github.com/user-attachments/assets/e1b11be3-d053-48c7-a084-666a228ce620" />



