### PR TITLE
mes-10679-IPadOS26-authTimeoutWorkaround

### DIFF
--- a/src/app/pages/communication/communication.page.ts
+++ b/src/app/pages/communication/communication.page.ts
@@ -197,9 +197,10 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
     }
 
     try {
-      await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode);
-      this.store$.dispatch(CommunicationSubmitInfo());
-      await this.routeByCat.navigateToPage(TestFlowPageNames.WAITING_ROOM_TO_CAR_PAGE, this.testCategory);
+      if (await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode)) {
+        this.store$.dispatch(CommunicationSubmitInfo());
+        await this.routeByCat.navigateToPage(TestFlowPageNames.WAITING_ROOM_TO_CAR_PAGE, this.testCategory);
+      }
     } catch (err) {
       this.store$.dispatch(CommunicationSubmitInfoError(err));
     }
@@ -324,11 +325,6 @@ export class CommunicationPage extends PracticeableBasePageComponent implements 
   }
 
   async canDeActivate(): Promise<boolean> {
-    try {
-      await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode);
-      return true;
-    } catch {
-      return false;
-    }
+    return await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode);
   }
 }

--- a/src/app/pages/health-declaration/health-declaration.page.ts
+++ b/src/app/pages/health-declaration/health-declaration.page.ts
@@ -97,12 +97,7 @@ export class HealthDeclarationPage
   }
 
   async canDeActivate(): Promise<boolean> {
-    try {
-      await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode);
-      return true;
-    } catch {
-      return false;
-    }
+    return await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode);
   }
 
   ngOnInit(): void {

--- a/src/app/pages/waiting-room/waiting-room.page.ts
+++ b/src/app/pages/waiting-room/waiting-room.page.ts
@@ -224,12 +224,7 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
   }
 
   async canDeActivate() {
-    try {
-      await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode);
-      return true;
-    } catch {
-      return false;
-    }
+    return await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode);
   }
 
   isJournalDataInvalid = (journalData: JournalData): boolean => {
@@ -280,9 +275,8 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
       const shouldNavToCandidateLicenceDetails: boolean = this.shouldNavigateToCandidateLicenceDetails();
 
       if (shouldNavToCandidateLicenceDetails) {
-        try {
-          await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode);
-        } catch {
+        const isAuthed = await this.deviceAuthenticationProvider.triggerLockScreen(this.isEndToEndPracticeMode);
+        if (!isAuthed) {
           return;
         }
       }
@@ -295,7 +289,6 @@ export class WaitingRoomPage extends PracticeableBasePageComponent implements On
           ? [TestFlowPageNames.CANDIDATE_LICENCE_PAGE]
           : [TestFlowPageNames.COMMUNICATION_PAGE]
       );
-      return;
     }
 
     Object.keys(this.formGroup.controls).forEach((controlName) => {

--- a/src/app/providers/device-authentication/__tests__/device-authentication.spec.ts
+++ b/src/app/providers/device-authentication/__tests__/device-authentication.spec.ts
@@ -112,7 +112,6 @@ describe('DeviceAuthenticationProvider', () => {
         reason: 'Please authenticate',
         useFallback: true,
       });
-      expect(loadingProvider.handleUILoading).not.toHaveBeenCalled();
       expect(deviceProvider.enableSingleAppMode).not.toHaveBeenCalled();
     });
   });

--- a/src/app/providers/device-authentication/device-authentication.ts
+++ b/src/app/providers/device-authentication/device-authentication.ts
@@ -22,11 +22,11 @@ export class DeviceAuthenticationProvider {
     private logHelper: LogHelper
   ) {}
 
-  triggerLockScreen = async (isPracticeMode = false): Promise<void> => {
+  triggerLockScreen = async (isPracticeMode = false): Promise<boolean> => {
     try {
       await this.platform.ready();
 
-      if (this.shouldBypassDeviceAuth()) return;
+      if (this.shouldBypassDeviceAuth()) return true;
 
       return await this.performBiometricVerification(isPracticeMode);
     } catch (err) {
@@ -39,21 +39,27 @@ export class DeviceAuthenticationProvider {
     return !this.platform.is('cordova') || this.appConfig.getAppConfig()?.role === ExaminerRole.DLG;
   };
 
-  performBiometricVerification = async (isPracticeMode = false): Promise<void> => {
+  performBiometricVerification = async (isPracticeMode = false): Promise<boolean> => {
+    let successfullyAuthenticated = true;
     try {
+      await this.loadingProvider.handleUILoading(true);
       await this.deviceProvider.disableSingleAppMode();
-
+      // Wait for a short duration to ensure that single app mode is disabled fully (THIS CODE WILL NOT WORK CONSISTENTLY ON IPADOS 26 IF THIS LINE IS NOT PRESENT)
+      await new Promise((resolve) => setTimeout(resolve, 75));
       await NativeBiometric.verifyIdentity({
         reason: 'Please authenticate',
         useFallback: true, // fallback to passcode if biometric authentication unavailable
       });
+    } catch (err) {
+      successfullyAuthenticated = false;
+      this.logEvent(err);
     } finally {
       if (!isPracticeMode) {
-        await this.loadingProvider.handleUILoading(true);
         await this.deviceProvider.enableSingleAppMode();
-        await this.loadingProvider.handleUILoading(false);
       }
+      await this.loadingProvider.handleUILoading(false);
     }
+    return successfullyAuthenticated;
   };
 
   public logEvent = (err: Error) => {

--- a/src/components/common/terminate-test-modal/__tests__/terminate-test-modal.spec.ts
+++ b/src/components/common/terminate-test-modal/__tests__/terminate-test-modal.spec.ts
@@ -60,18 +60,18 @@ describe('TerminateTestModal', () => {
         await component.terminationWrapper();
         expect(deviceAuthenticationProvider.triggerLockScreen).toHaveBeenCalled();
       });
-      it('should not call the onTerminate callback when the lock screen Promise rejects', async () => {
+      it('should not call the onTerminate callback when the lock screen returns false', async () => {
         deviceAuthenticationProvider.triggerLockScreen = jasmine
           .createSpy('triggerLockScreen')
-          .and.callFake(() => Promise.reject(new Error('err')));
+          .and.returnValue(Promise.resolve(false));
         component.shouldAuthenticate = true;
         await component.terminationWrapper();
         expect(component.onTerminate).not.toHaveBeenCalled();
       });
-      it('should call the onTerminate callback when the lock screen Promise resolves', async () => {
+      it('should call the onTerminate callback when the lock screen returns true', async () => {
         deviceAuthenticationProvider.triggerLockScreen = jasmine
           .createSpy('triggerLockScreen')
-          .and.returnValue(Promise.resolve('y'));
+          .and.returnValue(Promise.resolve(true));
         component.shouldAuthenticate = true;
         await component.terminationWrapper();
         expect(component.onTerminate).toHaveBeenCalled();

--- a/src/components/common/terminate-test-modal/terminate-test-modal.ts
+++ b/src/components/common/terminate-test-modal/terminate-test-modal.ts
@@ -23,16 +23,14 @@ export class TerminateTestModal {
    * Fired when the termination of the test is confirmed.
    * Handles re-authentication and subsequent delegation to the onTerminate callback.
    */
-  terminationWrapper(): Promise<void> {
+  async terminationWrapper(): Promise<void> {
     if (this.shouldAuthenticate) {
-      return this.deviceAuthenticationProvider
-        .triggerLockScreen(this.isPracticeMode)
-        .then(() => {
-          this.onTerminate();
-        })
-        .catch((err) => err);
+      if (await this.deviceAuthenticationProvider.triggerLockScreen(this.isPracticeMode)) {
+        this.onTerminate();
+      }
+    } else {
+      this.onTerminate();
     }
-    this.onTerminate();
     return Promise.resolve();
   }
 }


### PR DESCRIPTION
## Description
-Added workaround for password screen freeze.
-Refactored the existing function to return a bool for clarity and logging purposes. 
-Moved the loading spinner to cover the entire process, showing that the app is not frozen and not allowing users to click the button multiple times, causing additional issues
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
