### PR TITLE
mes-10698-closeButtonOnBurgerMenuPages

### DIFF
--- a/src/app/pages/examiner-records/examiner-records.page.html
+++ b/src/app/pages/examiner-records/examiner-records.page.html
@@ -1,14 +1,12 @@
 <ion-header>
   <ion-toolbar mode="ios">
-    <ion-buttons id="pass-cert-burger-menu-btn" slot="start">
-      <ion-menu-button></ion-menu-button>
-    </ion-buttons>
     <ion-buttons slot="end">
       <ion-button
         class="mes-white-button"
         id="examiner-records-return-to-dashboard-btn"
         (click)="goToDashboard()">
-        Exit
+        <ion-icon class="close-btn" name="close-outline"></ion-icon>
+        <ion-label class="close-btn">Close</ion-label>
       </ion-button>
     </ion-buttons>
     <ion-title role="heading" aria-level="1" id="examiner-records-page-title">Examiner records</ion-title>

--- a/src/app/pages/unuploaded-tests/unuploaded-tests.page.html
+++ b/src/app/pages/unuploaded-tests/unuploaded-tests.page.html
@@ -1,14 +1,12 @@
 <ion-header>
   <ion-toolbar mode="ios">
-    <ion-buttons id="unuploaded-burger-menu-btn" slot="start">
-      <ion-menu-button></ion-menu-button>
-    </ion-buttons>
     <ion-buttons slot="end">
       <ion-button
         class="white-text"
         id="unuploaded-tests-return-to-dashboard-btn"
         (click)="goToDashboard()">
-        Exit
+        <ion-icon class="close-btn" name="close-outline"></ion-icon>
+        <ion-label class="close-btn">Close</ion-label>
       </ion-button>
     </ion-buttons>
     <ion-title id="unsubmitted-tests-page-title" role="heading" aria-level="1">Unsubmitted tests</ion-title>
@@ -33,7 +31,7 @@
   <div class="header-divider"></div>
 
   <ion-text class="des-header-style-2">
-    You have {{state.slots?.length || 0}} incomplete {{getTestsText(state.slots?.length)}} (over 1 day old)
+    You have {{ state.slots?.length || 0 }} incomplete {{ getTestsText(state.slots?.length) }} (over 1 day old)
   </ion-text>
 
   <test-slot

--- a/src/app/pages/useful-links/useful-links.page.html
+++ b/src/app/pages/useful-links/useful-links.page.html
@@ -1,14 +1,12 @@
 <ion-header>
   <ion-toolbar mode="ios">
-    <ion-buttons id="useful-links-burger-menu-btn" slot="start">
-      <ion-menu-button></ion-menu-button>
-    </ion-buttons>
     <ion-buttons slot="end">
       <ion-button
         class="white-text"
         id="useful-links-return-to-dashboard-btn"
         (click)="goToDashboard()">
-        Exit
+        <ion-icon class="close-btn" name="close-outline"></ion-icon>
+        <ion-label class="close-btn">Close</ion-label>
       </ion-button>
     </ion-buttons>
     <ion-title id="useful-links-page-title" role="heading" aria-level="1">Useful links</ion-title>


### PR DESCRIPTION
## Description
Removed burger menu from every page that requires it to access, replaced exit button with the generic close button

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="936" height="152" alt="image" src="https://github.com/user-attachments/assets/ad4f9e40-f081-44bd-9e96-38d0a162f62b" />
<img width="931" height="309" alt="image" src="https://github.com/user-attachments/assets/a1a364ca-a44a-4758-8c72-a6f86c02919a" />
<img width="937" height="174" alt="image" src="https://github.com/user-attachments/assets/4b0610cc-e6c0-417d-8fa4-e1c98797a2a3" />
