### PR TITLE
Feature (mes 10731): remove Individual mitos from selection options 

### DIFF
--- a/.github/workflows/build-mobile-app-artefact.yaml
+++ b/.github/workflows/build-mobile-app-artefact.yaml
@@ -11,12 +11,6 @@ on:
         type: choice
         options:
           - 'MACOS-ARM64'
-          - 'm4-2'
-          - 'm4-3'
-          - 'mito-8'
-          - 'mito-7'
-          - 'mito-6'
-          - 'mito-2'
   push:
     branches:
       - develop


### PR DESCRIPTION
## Description

While it is a useful tool for debugging MITOs when there's one that requires updates or is other wise not building we want to avoid it being used for selecting specific MITOs for building with other wise we could end up with a case of having a branch merged that only runs on one of the MITOs and not the others.

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
