### PR TITLE
mes-8906-inconsistentValidation

### DIFF
--- a/src/app/pages/office/components/weather-conditions/__tests__/weather-condition.spec.ts
+++ b/src/app/pages/office/components/weather-conditions/__tests__/weather-condition.spec.ts
@@ -48,10 +48,25 @@ describe('WeatherConditionsComponent', () => {
 
   describe('weatherConditionsChanged', () => {
     it('should emit weatherConditions', () => {
+      component.formControl = new UntypedFormControl([]);
       spyOn(component.weatherConditionsChange, 'emit');
 
       component.weatherConditionsChanged(['Showers']);
       expect(component.weatherConditionsChange.emit).toHaveBeenCalledWith(['Showers']);
+    });
+    it('should mark the field as pristine if the passed array is empty', () => {
+      component.formControl = new UntypedFormControl([]);
+      spyOn(component.formControl, 'markAsPristine');
+
+      component.weatherConditionsChanged([]);
+      expect(component.formControl.markAsPristine).toHaveBeenCalled();
+    });
+    it('should not mark the field as pristine if the passed array is empty', () => {
+      component.formControl = new UntypedFormControl([]);
+      spyOn(component.formControl, 'markAsPristine');
+
+      component.weatherConditionsChanged(['Icy']);
+      expect(component.formControl.markAsPristine).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/pages/office/components/weather-conditions/weather-conditions.ts
+++ b/src/app/pages/office/components/weather-conditions/weather-conditions.ts
@@ -54,6 +54,9 @@ export class WeatherConditionsComponent implements OnChanges {
   }
 
   weatherConditionsChanged(weatherConditions: WeatherConditions[]): void {
+    if (weatherConditions.length === 0) {
+      this.formControl.markAsPristine();
+    }
     this.weatherConditionsChange.emit(weatherConditions);
   }
 


### PR DESCRIPTION
## Description
Fixed a bug where inputting an empty array in the weather box selector would output a validation error
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
