### PR TITLE
mes-release-9978-NamesClippingOnTestResult

### DIFF
--- a/src/app/pages/view-test-result/components/view-test-header/view-test-header.html
+++ b/src/app/pages/view-test-result/components/view-test-header/view-test-header.html
@@ -1,10 +1,10 @@
 <ion-row class="header-row ion-text-wrap" id="candidate-section">
-  <ion-col>
+  <ion-col size="59">
     <ion-text class="des-header-style-2" id="candidateName">{{data.candidateName}}</ion-text>
     <br />
     <span id="candidateDriverNumber" class="driver-number-class">{{data.candidateDriverNumber}}</span>
   </ion-col>
-  <ion-col size="auto" class="ion-text-end">
+  <ion-col size="37" class="ion-text-end">
     <ion-text class="des-header-style-2" id="activityCode">{{data.activityCode}}</ion-text>
     <br />
     <ion-text [ngClass]="['des-header-style-3', data.grade ? 'grade-styling' : '']"

--- a/src/app/pages/view-test-result/components/view-test-header/view-test-header.html
+++ b/src/app/pages/view-test-result/components/view-test-header/view-test-header.html
@@ -1,10 +1,10 @@
 <ion-row class="header-row ion-text-wrap" id="candidate-section">
-  <ion-col size="59">
+  <ion-col size="48">
     <ion-text class="des-header-style-2" id="candidateName">{{data.candidateName}}</ion-text>
     <br />
     <span id="candidateDriverNumber" class="driver-number-class">{{data.candidateDriverNumber}}</span>
   </ion-col>
-  <ion-col size="37" class="ion-text-end">
+  <ion-col size="48" class="ion-text-end">
     <ion-text class="des-header-style-2" id="activityCode">{{data.activityCode}}</ion-text>
     <br />
     <ion-text [ngClass]="['des-header-style-3', data.grade ? 'grade-styling' : '']"


### PR DESCRIPTION
## Description
Fixed an issue where test outcome would clip underneath the page
## Checklist

- [X] PR title includes the JIRA ticket number
- [X] Branch is rebased against the latest develop
- [X] Code has been tested manually
- [X] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="936" height="512" alt="image" src="https://github.com/user-attachments/assets/fca2b7f9-d12f-46cb-829a-0bb313efce35" />
<img width="930" height="439" alt="image" src="https://github.com/user-attachments/assets/a333a914-85fb-4e8e-887f-a04978441798" />
