### PR TITLE
mes-11122-revertSponsorForADI2

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -7,26 +7,16 @@ ignore:
     - '*':
         reason: Use of LGPL-3.0 licensed package
         created: 2026-02-12T15:06:00.122Z
-  SNYK-JS-XMLDOMXMLDOM-16133132:
+  SNYK-JS-SNYK-JS-QS-16721866:
     - '*':
         reason: Remediation not yet available
-        expires: 2026-05-27T09:00:00.119Z
-        created: 2023-04-27T09:00:00.122Z
-  SNYK-JS-XMLDOMXMLDOM-16134530:
+        expires: 2026-06-18T11:41:00.122Z
+        created: 2026-05-18T11:41:00.122Z
+  SNYK-JS-QS-16721866:
     - '*':
         reason: Remediation not yet available
-        expires: 2026-05-27T09:00:00.119Z
-        created: 2023-04-27T09:00:00.122Z
-  SNYK-JS-XMLDOMXMLDOM-16134549:
-      - '*':
-        reason: Remediation not yet available
-        expires: 2026-09-01T09:00:00.119Z
-        created: 2026-04-29T11:30:00.122Z
-  SNYK-JS-XMLDOMXMLDOM-16134552:
-    - '*':
-        reason: Remediation not yet available
-        expires: 2026-05-27T09:00:00.119Z
-        created: 2023-04-27T09:00:00.122Z
+        expires: 2026-06-18T11:41:00.122Z
+        created: 2026-05-18T11:41:00.122Z
   SNYK-JS-UUID-16133035:
     - '*':
         reason: Remediation not yet available

--- a/src/app/pages/view-test-result/view-test-result.page.ts
+++ b/src/app/pages/view-test-result/view-test-result.page.ts
@@ -385,8 +385,9 @@ export class ViewTestResultPage extends BasePageComponent implements OnInit {
   }
 
   getPrnLabel(): string {
-    return compareVersions.compare(get(this.testResult, 'appVersion'), '4.29.0.0', '<')
-      ? 'Trainer PRN'
-      : `Sponsor's PRN`;
+    if (compareVersions.compare(get(this.testResult, 'appVersion'), '4.29.0.0', '<')) {
+      return "Trainer's PRN";
+    }
+    return this.isADI3() ? "Sponsor's PRN" : "Trainer's PRN";
   }
 }

--- a/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.ts
+++ b/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.ts
@@ -20,7 +20,7 @@ export class TrainerRegistrationNumberCatAdiPart2Component implements OnChanges 
   formGroup: UntypedFormGroup;
 
   @Input()
-  trainerLabel = `Sponsor's PRN (optional)`;
+  trainerLabel = `Trainer's PRN (optional)`;
 
   @Output()
   trainerRegistrationChange = new EventEmitter<number>();

--- a/src/app/pages/waiting-room-to-car/cat-adi-part2/waiting-room-to-car.cat-adi-part2.page.html
+++ b/src/app/pages/waiting-room-to-car/cat-adi-part2/waiting-room-to-car.cat-adi-part2.page.html
@@ -135,7 +135,7 @@
                 (trainerRegistrationChange)="trainerRegistrationNumberChanged($event)"
                 [formGroup]="form"
                 [trainerRegistration]="pageState.trainerRegistrationNumber$ | async"
-                [trainerLabel]="`Sponsor's PRN (optional)`"
+                [trainerLabel]="`Trainer's PRN (optional)`"
               >
               </trainer-registration-number-cat-adi-part2>
 


### PR DESCRIPTION
## Description
Reverted ADI 2 to Trainer's VRN instead of Sponsor
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="539" height="431" alt="image" src="https://github.com/user-attachments/assets/819cdd43-a232-4254-8309-a25450173c23" />
<img width="549" height="224" alt="image" src="https://github.com/user-attachments/assets/0de715a6-8f52-4d5c-9faf-1168b1d9f067" />
<img width="503" height="226" alt="image" src="https://github.com/user-attachments/assets/85f3585e-9d62-43ad-a856-04e8af11d743" />
