### PR TITLE
feat: ADI2 change input of PRN to text

### DIFF
--- a/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/__tests__/trainer-registration-number.cat-adi-part2.spec.ts
+++ b/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/__tests__/trainer-registration-number.cat-adi-part2.spec.ts
@@ -28,15 +28,12 @@ describe('TrainerRegistrationNumberCatAdiPart2Component', () => {
   });
 
   describe('ngOnChanges', () => {
-    it(
-      'should have trainerRegistration form control be added to ' + 'form if there is no form control already there',
-      () => {
-        component.formControl = null;
-        component.ngOnChanges();
+    it('should have trainerRegistration form control be added to form if there is no form control already there', () => {
+      component.formControl = null;
+      component.ngOnChanges();
 
-        expect(component.formGroup.controls.trainerRegistration).toBeTruthy();
-      }
-    );
+      expect(component.formGroup.controls[TrainerRegistrationNumberCatAdiPart2Component.fieldName]).toBeTruthy();
+    });
   });
 
   describe('invalid', () => {
@@ -66,7 +63,7 @@ describe('TrainerRegistrationNumberCatAdiPart2Component', () => {
     });
   });
 
-  describe('vehicleRegistrationChanged', () => {
+  describe('trainerRegistrationChanged', () => {
     beforeEach(() => {
       spyOn(component.trainerRegistrationChange, 'emit');
     });
@@ -76,24 +73,24 @@ describe('TrainerRegistrationNumberCatAdiPart2Component', () => {
       expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(1234567);
     });
 
-    it('should remove non-numeric characters and emit the value as number', () => {
+    it('should emit NaN for a string containing non-numeric characters', () => {
       component.trainerRegistrationChanged(mockInvalidTrainerRegNumber);
-      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(12457);
+      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(Number.NaN);
     });
 
-    it('should remove preceding zeros and emit rest of valid result', () => {
+    it('should emit the numeric value, stripping leading zeros via Number()', () => {
       component.trainerRegistrationChanged(mockLeadingZeroTrainerRegNumber);
       expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(4567);
     });
 
-    it('should remove preceding zeros and emit undefined as empty', () => {
+    it('should emit 0 for a string containing only zero', () => {
       component.trainerRegistrationChanged(mockOnlyZeroTrainerRegNumber);
-      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(undefined);
+      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(0);
     });
 
-    it('should emit undefined as the value can`t be cast to a number', () => {
+    it('should emit 0 for an empty string', () => {
       component.trainerRegistrationChanged(mockBlankTrainerRegNumber);
-      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(undefined);
+      expect(component.trainerRegistrationChange.emit).toHaveBeenCalledWith(0);
     });
   });
 });

--- a/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/__tests__/trainer-registration-number.mock.ts
+++ b/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/__tests__/trainer-registration-number.mock.ts
@@ -1,19 +1,5 @@
-export const mockValidTrainerRegNumber: HTMLInputElement = {
-  value: '1234567',
-} as HTMLInputElement;
-
-export const mockInvalidTrainerRegNumber: HTMLInputElement = {
-  value: '12£45H7',
-} as HTMLInputElement;
-
-export const mockLeadingZeroTrainerRegNumber: HTMLInputElement = {
-  value: '04567',
-} as HTMLInputElement;
-
-export const mockOnlyZeroTrainerRegNumber: HTMLInputElement = {
-  value: '0',
-} as HTMLInputElement;
-
-export const mockBlankTrainerRegNumber: HTMLInputElement = {
-  value: '',
-} as HTMLInputElement;
+export const mockValidTrainerRegNumber = '1234567';
+export const mockInvalidTrainerRegNumber = '12£45H7';
+export const mockLeadingZeroTrainerRegNumber = '04567';
+export const mockOnlyZeroTrainerRegNumber = '0';
+export const mockBlankTrainerRegNumber = '';

--- a/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.html
+++ b/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.html
@@ -8,15 +8,15 @@
     <ion-row>
       <ion-col size="32">
         <ion-input
+          [class.ng-invalid]="invalid"
           type="text"
           inputmode="numeric"
           numbersOnly
           id="trainer-registration"
-          formControlName="trainerRegistration"
+          formControlName="trainerRegistrationCtrl"
           class="ion-input-styling increase-width"
           aria-labelledby="trainer-prn-label"
-          [maxlength]="trainerRegistrationNumberValidator.maxLength"
-          (ionChange)="trainerRegistrationChanged($event.target)"
+          (ionChange)="trainerRegistrationChanged($event.target.value)"
           emojiBlock
           pasteSanitiser
         >

--- a/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.html
+++ b/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.html
@@ -8,7 +8,8 @@
     <ion-row>
       <ion-col size="32">
         <ion-input
-          type="number"
+          type="text"
+          inputmode="numeric"
           numbersOnly
           id="trainer-registration"
           formControlName="trainerRegistration"

--- a/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.ts
+++ b/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.ts
@@ -32,9 +32,6 @@ export class TrainerRegistrationNumberCatAdiPart2Component implements OnChanges 
     if (!this.formControl) {
       this.formControl = new UntypedFormControl(null, [
         Validators.maxLength(Number(this.trainerRegistrationNumberValidator.maxLength)),
-        Validators.minLength(Number(this.trainerRegistrationNumberValidator.maxLength)),
-        Validators.pattern(this.trainerRegistrationNumberValidator.pattern),
-        Validators.required,
       ]);
       this.formGroup.addControl(TrainerRegistrationNumberCatAdiPart2Component.fieldName, this.formControl);
     }

--- a/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.ts
+++ b/src/app/pages/waiting-room-to-car/cat-adi-part2/components/trainer-registration-number/trainer-registration-number.cat-adi-part2.ts
@@ -1,10 +1,8 @@
 import { Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
-import { UntypedFormControl, UntypedFormGroup } from '@angular/forms';
+import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import {
   FieldValidators,
   getTrainerRegistrationNumberValidator,
-  leadingZero,
-  nonNumericValues,
 } from '@shared/constants/field-validators/field-validators';
 
 @Component({
@@ -26,22 +24,25 @@ export class TrainerRegistrationNumberCatAdiPart2Component implements OnChanges 
   trainerRegistrationChange = new EventEmitter<number>();
 
   formControl: UntypedFormControl;
+  static readonly fieldName: string = 'trainerRegistrationCtrl';
 
   readonly trainerRegistrationNumberValidator: FieldValidators = getTrainerRegistrationNumberValidator();
 
   ngOnChanges(): void {
     if (!this.formControl) {
-      this.formControl = new UntypedFormControl(null);
-      this.formGroup.addControl('trainerRegistration', this.formControl);
+      this.formControl = new UntypedFormControl(null, [
+        Validators.maxLength(Number(this.trainerRegistrationNumberValidator.maxLength)),
+        Validators.minLength(Number(this.trainerRegistrationNumberValidator.maxLength)),
+        Validators.pattern(this.trainerRegistrationNumberValidator.pattern),
+        Validators.required,
+      ]);
+      this.formGroup.addControl(TrainerRegistrationNumberCatAdiPart2Component.fieldName, this.formControl);
     }
     this.formControl.patchValue(this.trainerRegistration);
   }
 
-  trainerRegistrationChanged(input: HTMLInputElement): void {
-    if (typeof input.value === 'string' && !this.trainerRegistrationNumberValidator.pattern.test(input.value)) {
-      input.value = input.value.replace(leadingZero, '').replace(nonNumericValues, '');
-    }
-    this.trainerRegistrationChange.emit(Number(input.value) || undefined);
+  trainerRegistrationChanged(trainerNumber): void {
+    this.trainerRegistrationChange.emit(Number(trainerNumber));
   }
 
   get invalid(): boolean {


### PR DESCRIPTION
## Description

ADI2 - change input of PRN to text to allow old validation to be restored whilst keeping the numeric keyboard.

https://dvsa.atlassian.net/browse/MES-11124

## Checklist

- [ ] PR title includes the JIRA ticket number
- [ ] Branch is rebased against the latest develop
- [ ] Code has been tested manually
- [ ] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)

screenshots to show keyboard type doesnt change.

old:

<img width="1436" height="1400" alt="image" src="https://github.com/user-attachments/assets/9251fc29-7e86-488e-aa1c-ae18082b4852" />


new:

<img width="800" height="610" alt="image" src="https://github.com/user-attachments/assets/5ee52ea4-a511-435f-b634-5c93dd26fd6d" />
