### PR TITLE
mes-10180-removeAssessmentFromTestReport

### DIFF
--- a/src/app/pages/test-report-dashboard/test-report-dashboard.page.html
+++ b/src/app/pages/test-report-dashboard/test-report-dashboard.page.html
@@ -29,7 +29,7 @@
   <ion-row class="mes-full-width-card-small-top ion-nowrap">
     <ion-col size="60">
       <h2 id="adi-pt3-dashboard-title" class="normal-font-weight ion-padding-start des-header-style-2">
-        {{ testCategory === 'SC' ? 'Standards check' : 'ADI part 3' }} assessment
+        {{ testCategory === 'SC' ? 'Standards check' : 'ADI part 3' }}
       </h2>
     </ion-col>
     <ion-col>

--- a/src/app/pages/test-report/cat-adi-part3/test-report.cat-adi-part3.page.html
+++ b/src/app/pages/test-report/cat-adi-part3/test-report.cat-adi-part3.page.html
@@ -29,7 +29,7 @@
     <ion-row class="mes-full-width-card-small-top ion-nowrap">
       <ion-col size="60">
         <h2 id="adi-pt3-assessment-lesson-theme-title" class="normal-font-weight ion-padding-start des-header-style-2">
-          {{testCategory === 'SC' ? 'Standards check' : 'ADI part 3'}} assessment
+          {{testCategory === 'SC' ? 'Standards check' : 'ADI part 3'}}
         </h2>
       </ion-col>
       <ion-col size="36">
@@ -59,7 +59,7 @@
     <ion-row class="mes-full-width-card-small-top ion-nowrap">
       <ion-col size="60">
         <h2 id="adi-pt3-assessment-test-report-title" class="normal-font-weight ion-padding-start des-header-style-2">
-          {{testCategory === 'SC' ? 'Standards check' : 'ADI part 3'}} assessment
+          {{testCategory === 'SC' ? 'Standards check' : 'ADI part 3'}}
         </h2>
       </ion-col>
       <ion-col size="36">

--- a/src/app/pages/test-report/cat-cpc/components/module-assessment/module-assessment.html
+++ b/src/app/pages/test-report/cat-cpc/components/module-assessment/module-assessment.html
@@ -1,6 +1,6 @@
 <ion-row class="mes-full-width-card-small-top ion-nowrap">
   <ion-col size="60">
-    <h2 id="cpc-module-assessment-title" class="des-header-style-2">CPC module assessment</h2>
+    <h2 id="cpc-module-assessment-title" class="des-header-style-2">CPC module</h2>
   </ion-col>
   <ion-col size="36" class="align-col-right">
     <ion-text class="ion-no-margin des-header-style-3" id="combination-label">


### PR DESCRIPTION
## Description
Removed the word assessment from various category's test report pages
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="937" height="182" alt="image" src="https://github.com/user-attachments/assets/751d8ae7-15d6-480a-ac69-c45f59ea7845" />
<img width="935" height="155" alt="image" src="https://github.com/user-attachments/assets/096434d8-7b90-40d1-8688-c35ed5d985aa" />
<img width="927" height="159" alt="image" src="https://github.com/user-attachments/assets/0bb8db61-6c73-4c0e-9f26-864f85515819" />
