### PR TITLE
mes-10206-uncenteredCombinationOnCPCOffice

### DIFF
--- a/src/app/pages/office/cat-cpc/components/combination/combination.html
+++ b/src/app/pages/office/cat-cpc/components/combination/combination.html
@@ -9,7 +9,7 @@
       <ion-col class="ion-align-self-center">
         <label id="combination-label"
           >{{getCombinationText(combination)}}
-          <span *ngIf="combinationAdditionalText">- {{combinationAdditionalText}}</span>
+          <label *ngIf="combinationAdditionalText">- {{combinationAdditionalText}}</label>
         </label>
       </ion-col>
     </ion-row>


### PR DESCRIPTION
## Description
Combination text on cpc office is now properly centered and sized
## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="416" height="121" alt="image" src="https://github.com/user-attachments/assets/66279ab1-115d-4bc7-b7c4-b0cf60924deb" />
