### PR TITLE
mes-10506-correctLegendTextSizeADI3

### DIFF
--- a/src/app/pages/view-test-result/view-test-result.page.html
+++ b/src/app/pages/view-test-result/view-test-result.page.html
@@ -101,6 +101,7 @@
 
     @if ((isCategoryADI3() || isCategorySC()) && !didTestTerminate()) {
       <adi3-debrief-card
+        [isOnResultsPage]="true"
         [testCategory]="testCategory"
         [totalScore]="totalScore"
         [lessonTheme]="testResult.testData['lessonAndTheme']"

--- a/src/components/common/adi3-debrief-card/adi3-debrief-card.html
+++ b/src/components/common/adi3-debrief-card/adi3-debrief-card.html
@@ -40,29 +40,29 @@
     </ion-card>
   }
 
-  <ion-row class="scoring-text">
-    <ion-col size="14">
-      <ion-row class="opposing-text">
-        <ion-col size="10"><strong>0</strong></ion-col>
-        <ion-col size="86"> - No evidence</ion-col>
+  <ion-row class="scoring-text" [class.scoring-row-padding]="!isOnResultsPage">
+    <ion-col class="display-flex ion-align-items-center" size="16">
+      <ion-row class="width-100 opposing-text">
+        <ion-col class="ion-no-padding-important" size="auto"><strong>0</strong></ion-col>
+        <ion-col class="ion-no-padding-important"> - No evidence</ion-col>
       </ion-row>
     </ion-col>
-    <ion-col class="score-1-spacing">
-      <ion-row class="opposing-text">
-        <ion-col size="5"><strong>1</strong></ion-col>
-        <ion-col size="91"> - Demonstrated in a few elements</ion-col>
+    <ion-col class="display-flex ion-align-items-center">
+      <ion-row class="width-100 opposing-text">
+        <ion-col class="ion-no-padding-important" size="auto"><strong>1</strong></ion-col>
+        <ion-col class="ion-no-padding-important"> - Demonstrated in a few elements</ion-col>
       </ion-row>
     </ion-col>
-    <ion-col>
-      <ion-row class="opposing-text">
-        <ion-col size="5"><strong>2</strong></ion-col>
-        <ion-col size="91"> - Demonstrated in most elements</ion-col>
+    <ion-col class="display-flex ion-align-items-center">
+      <ion-row class="width-100 opposing-text">
+        <ion-col class="ion-no-padding-important" size="auto"><strong>2</strong></ion-col>
+        <ion-col class="ion-no-padding-important"> - Demonstrated in most elements</ion-col>
       </ion-row>
     </ion-col>
-    <ion-col>
-      <ion-row class="opposing-text">
-        <ion-col size="5"><strong>3</strong></ion-col>
-        <ion-col size="91"> - Demonstrated in all elements</ion-col>
+    <ion-col class="display-flex ion-align-items-center">
+      <ion-row class="width-100 opposing-text">
+        <ion-col class="ion-no-padding-important" size="auto"><strong>3</strong></ion-col>
+        <ion-col class="ion-no-padding-important"> - Demonstrated in all elements</ion-col>
       </ion-row>
     </ion-col>
   </ion-row>

--- a/src/components/common/adi3-debrief-card/adi3-debrief-card.scss
+++ b/src/components/common/adi3-debrief-card/adi3-debrief-card.scss
@@ -1,7 +1,7 @@
 :host {
   .tr-standard-text {
     font-weight: bold;
-    font-size: 20px !important;
+    font-size: 24px !important;
     color: var(--gds-theme-opposite);
   }
 
@@ -10,7 +10,11 @@
   }
 
   .scoring-text {
-    font-size: 12.5px;
+    color: var(--gds-theme-opposite);
+  }
+
+  .scoring-row-padding {
+    padding: 8px 8px 8px 8px;
   }
 
   .score-1-spacing {

--- a/src/components/common/adi3-debrief-card/adi3-debrief-card.ts
+++ b/src/components/common/adi3-debrief-card/adi3-debrief-card.ts
@@ -40,6 +40,9 @@ export class Adi3DebriefCard implements OnInit {
   @Input()
   public testCategory: TestCategory;
 
+  @Input()
+  public isOnResultsPage = false;
+
   studentValueConst = studentValues;
   lessonThemeValueStr = '';
 


### PR DESCRIPTION
## Description
[Jira Ticket](https://dvsa.atlassian.net/browse/MES-10506)

Adjusted legend text on adi3 debrief card to comply with dynamic text sizing

## Checklist

- [x] PR title includes the JIRA ticket number
- [x] Branch is rebased against the latest develop
- [x] Code has been tested manually
- [x] PR link added to JIRA ticket
- [ ] One review from each scrum team
- [ ] Squashed commit contains the JIRA ticket number

## Screenshots (optional)
<img width="887" height="467" alt="image" src="https://github.com/user-attachments/assets/64de595c-8f31-4e53-b623-ee8e448eca53" />

<img width="880" height="500" alt="image" src="https://github.com/user-attachments/assets/8c8fac95-e6db-4362-82c3-53dd3306a852" />